### PR TITLE
Build mental model of classic resume Quill

### DIFF
--- a/proposals/quill-classic-resume-schema.md
+++ b/proposals/quill-classic-resume-schema.md
@@ -1,0 +1,416 @@
+# Proposal: classic_resume Quill Schema Redesign
+
+## Summary
+
+Redesign the `skills` and `certifications` cards to use BODY-centric content with markdown structure (headers for categories, bullets for lists), replacing the rigid `key1/val1` field pattern.
+
+---
+
+## Current State
+
+### Skills Card (Quill.toml)
+
+```toml
+[cards.skills]
+title = "Skills Grid (4 categories)"
+ui.metadata_only = true
+
+[cards.skills.fields.key1]
+type = "string"
+required = true
+# ... repeated for key2, key3, key4, val1, val2, val3, val4
+```
+
+### Skills Card (Markdown)
+
+```yaml
+---
+CARD: skills
+key1: Programming
+val1: Python, R, JS
+key2: Data Science
+val2: ML/statistics, TensorFlow
+key3: IT & Cybersecurity
+val3: AD DS, Splunk, Metasploit
+key4: Cloud
+val4: AWS EC2/S3, Helm, Docker
+---
+```
+
+### Problems
+
+1. **Rigid** - Exactly 4 categories, no more, no less
+2. **Repetitive** - `key1/val1` pattern violates DRY
+3. **No rich content** - Values are plain strings, no links/emphasis
+4. **Unnatural** - Doesn't feel like writing markdown
+5. **`ui.metadata_only = true`** - BODY is wasted
+
+---
+
+## Proposed Design
+
+### New `grid` Card
+
+A unified card that uses BODY content with markdown structure to determine rendering.
+
+#### Categorized Grid (Skills)
+
+```yaml
+---
+CARD: grid
+columns: 2
+---
+# Programming
+Python, R, JS, C#, Rust, PowerShell, CI/CD
+
+# Data Science
+ML/statistics, TensorFlow, AI Engineering
+
+# IT & Cybersecurity
+AD DS, Splunk, Metasploit, Wireshark, Nessus
+
+# Cloud
+AWS EC2/S3, Helm, Docker, Serverless
+```
+
+**Parsing logic:**
+- `# Header` → category key (bold in output)
+- Following paragraph(s) → category value
+- `columns` metadata controls grid layout
+
+#### Flat Grid (Certifications)
+
+```yaml
+---
+CARD: grid
+columns: 2
+---
+- Offensive Security Certified Professional (OSCP)
+- GIAC Cyber Threat Intelligence (GCTI)
+- CompTIA CASP+, CySA+, Sec+, Net+, A+, Proj+
+- GIAC Machine Learning Engineer (GMLE)
+```
+
+**Parsing logic:**
+- Bullet list → flat items
+- Each bullet becomes a grid cell
+- `columns` metadata controls grid layout
+
+#### Auto-Detection
+
+The Quillmark engine inspects BODY structure:
+
+| BODY starts with | Detected style | Rendering |
+|------------------|----------------|-----------|
+| `# Header` | categorized | Bold key + value below |
+| `- Bullet` | flat | Simple grid cells |
+| Paragraph | flat | Each paragraph = cell |
+
+---
+
+## Schema Changes
+
+### File: `Quill.toml`
+
+```toml
+# ==========================================
+# REMOVE: Old skills and certifications cards
+# ==========================================
+
+# [cards.skills]        # DELETED
+# [cards.certifications] # DELETED
+
+# ==========================================
+# ADD: New unified grid card
+# ==========================================
+
+[cards.grid]
+title = "Content Grid"
+description = """
+A flexible grid layout for skills, certifications, or any structured content.
+Use markdown headers (# Category) for key-value pairs, or bullets (- Item) for flat lists.
+"""
+
+[cards.grid.fields.columns]
+title = "Number of Columns"
+type = "integer"
+default = 2
+examples = [2, 3, 4]
+description = "How many columns to display in the grid"
+
+[cards.grid.fields.style]
+title = "Grid Style"
+type = "string"
+default = "auto"
+examples = ["auto", "categorized", "flat"]
+description = "Override auto-detection: 'categorized' for key-value, 'flat' for simple list"
+```
+
+### Backwards Compatibility (Optional)
+
+Keep old cards as aliases during migration:
+
+```toml
+[cards.skills]
+title = "Skills Grid"
+deprecated = true
+alias = "grid"
+description = "DEPRECATED: Use 'grid' card with # headers instead"
+
+[cards.certifications]
+title = "Certifications"
+deprecated = true
+alias = "grid"
+description = "DEPRECATED: Use 'grid' card with - bullets instead"
+```
+
+---
+
+## Plate Changes
+
+### File: `plate.typ`
+
+**Before:**
+
+```typst
+{% if card.CARD == "skills" %}
+  #category_grid(items: (
+    (key: {{ card.key1 | String }}, value: {{ card.val1 | String }}),
+    (key: {{ card.key2 | String }}, value: {{ card.val2 | String }}),
+    (key: {{ card.key3 | String }}, value: {{ card.val3 | String }}),
+    (key: {{ card.key4 | String }}, value: {{ card.val4 | String }}),
+  ))
+{% elif card.CARD == "certifications" %}
+  #item_grid(items: {{ card.items | Lines }})
+{% endif %}
+```
+
+**After:**
+
+```typst
+{% if card.CARD == "grid" %}
+  #content_grid(
+    items: {{ card.BODY | GridItems }},
+    columns: {{ card.columns | Int | default: 2 }},
+    style: {{ card.style | String | default: "auto" }},
+  )
+{% endif %}
+```
+
+### New Filter: `GridItems`
+
+The Quillmark engine needs a new filter that:
+
+1. Parses BODY markdown
+2. Detects structure (headers vs bullets)
+3. Returns Typst-compatible array
+
+**Pseudocode:**
+
+```python
+def grid_items_filter(body_markdown: str) -> str:
+    """Convert markdown BODY to Typst array literal."""
+
+    parsed = parse_markdown(body_markdown)
+
+    if starts_with_header(parsed):
+        # Categorized: extract header/content pairs
+        items = []
+        for section in extract_sections(parsed):
+            items.append({
+                "key": section.header,
+                "value": section.content
+            })
+        return to_typst_array(items, style="dict")
+
+    elif starts_with_bullet(parsed):
+        # Flat: extract bullet items
+        items = [item.text for item in extract_bullets(parsed)]
+        return to_typst_array(items, style="string")
+
+    else:
+        # Paragraphs: each paragraph is an item
+        items = [p.text for p in extract_paragraphs(parsed)]
+        return to_typst_array(items, style="string")
+```
+
+**Output examples:**
+
+```typst
+// Categorized (from headers)
+((key: "Programming", value: [Python, R, JS]), (key: "Data Science", value: [ML, TensorFlow]))
+
+// Flat (from bullets)
+("OSCP", "GCTI", "CompTIA CASP+")
+```
+
+---
+
+## Example Migration
+
+### Before (Old Schema)
+
+```markdown
+---
+CARD: section
+title: Skills
+---
+
+---
+CARD: skills
+key1: Programming
+val1: Python, R, JS, C#, Rust, PowerShell, CI/CD
+key2: Data Science
+val2: ML/statistics, TensorFlow, AI Engineering
+key3: IT & Cybersecurity
+val3: AD DS, Splunk, Metasploit, Wireshark, Nessus
+key4: Cloud
+val4: AWS EC2/S3, Helm, Docker, Serverless
+---
+
+---
+CARD: section
+title: Certifications
+---
+
+---
+CARD: certifications
+items:
+  - Offensive Security Certified Professional (OSCP)
+  - GIAC Cyber Threat Intelligence (GCTI)
+---
+```
+
+### After (New Schema)
+
+```markdown
+---
+CARD: section
+title: Skills
+---
+
+---
+CARD: grid
+columns: 2
+---
+# Programming
+Python, R, JS, C#, Rust, PowerShell, CI/CD
+
+# Data Science
+ML/statistics, TensorFlow, AI Engineering
+
+# IT & Cybersecurity
+AD DS, Splunk, Metasploit, Wireshark, Nessus
+
+# Cloud
+AWS EC2/S3, Helm, Docker, Serverless
+
+---
+CARD: section
+title: Certifications
+---
+
+---
+CARD: grid
+columns: 2
+---
+- Offensive Security Certified Professional (OSCP)
+- GIAC Cyber Threat Intelligence (GCTI)
+- CompTIA CASP+, CySA+, Sec+, Net+, A+, Proj+
+- GIAC Machine Learning Engineer (GMLE)
+```
+
+---
+
+## Rich Content Examples
+
+The new design enables rich markdown in values:
+
+```markdown
+---
+CARD: grid
+---
+# Programming
+Python, **R**, JavaScript, [Rust](https://rust-lang.org), PowerShell
+
+# Certifications
+[OSCP](https://offensive-security.com), _in progress:_ OSCE3
+```
+
+---
+
+## Consumer Impact Analysis
+
+### Human Authors
+
+| Aspect | Before | After |
+|--------|--------|-------|
+| Cognitive load | High (remember key1/val1 pattern) | Low (use familiar markdown) |
+| Flexibility | Fixed 4 categories | Unlimited categories |
+| Rich content | Not supported | Full markdown support |
+| Readability | Poor (YAML soup) | Good (natural prose) |
+
+### GUI Form Builders
+
+| Aspect | Before | After |
+|--------|--------|-------|
+| Field generation | Easy (8 text inputs) | Medium (markdown editor) |
+| Validation | Strong (required fields) | Weak (freeform) |
+| Preview | N/A | Render markdown preview |
+
+**Recommendation:** GUI could offer structured input mode (dynamic rows) that generates markdown, or a markdown editor with syntax highlighting.
+
+### LLM Consumers
+
+| Aspect | Before | After |
+|--------|--------|-------|
+| Token efficiency | Poor (verbose YAML) | Good (concise markdown) |
+| Generation quality | Medium (must follow schema) | High (natural markdown) |
+| Understanding | Good (explicit fields) | Good (semantic headers) |
+
+---
+
+## Implementation Phases
+
+### Phase 1: Add New Card
+- Add `grid` card to Quill.toml
+- Implement `GridItems` filter in Quillmark
+- Add `content_grid` to ttq-classic-resume
+- Update plate.typ with new card handling
+- Update example.md with new syntax
+
+### Phase 2: Deprecation
+- Mark `skills` and `certifications` as deprecated
+- Add migration documentation
+- Log warnings when deprecated cards used
+
+### Phase 3: Removal
+- Remove deprecated cards from schema
+- Remove old plate.typ conditionals
+- Update all examples and documentation
+
+---
+
+## Open Questions
+
+1. **Should `grid` support a `title` field?** To optionally include a section header, reducing card count:
+   ```yaml
+   ---
+   CARD: grid
+   title: Skills
+   columns: 2
+   ---
+   ```
+
+2. **What about 1-column "list" rendering?** Should `columns: 1` render as a styled list instead of single-column grid?
+
+3. **Should we support `## Subheaders`?** For nested categorization:
+   ```markdown
+   # Programming
+   ## Languages
+   Python, Rust, Go
+   ## Frameworks
+   React, FastAPI
+   ```
+
+4. **Error handling for malformed BODY?** What if user mixes headers and bullets? Fail or best-effort?

--- a/proposals/typst-ttq-classic-resume-grid.md
+++ b/proposals/typst-ttq-classic-resume-grid.md
@@ -1,0 +1,319 @@
+# Proposal: Typst ttq-classic-resume Grid Consolidation
+
+## Summary
+
+Consolidate `category_grid` and `item_grid` into a unified `content_grid` component that renders structured content based on input shape, supporting the new BODY-centric card design.
+
+---
+
+## Current State
+
+### Existing Components
+
+```typst
+// Category Grid - for key/value pairs (skills)
+#let category_grid(items: (), columns: 2)
+// items: ((key: "Programming", value: "Python, R"), ...)
+
+// Item Grid - for flat lists (certifications)
+#let item_grid(items: (), columns: 2)
+// items: ("OSCP", "GCTI", ...)
+```
+
+### Problems
+
+1. **Redundant APIs** - Both components do grid layout with minor rendering differences
+2. **Rigid input shape** - `category_grid` expects exactly `(key, value)` tuples
+3. **No content passthrough** - Cannot accept native Typst content from BODY
+4. **Caller decides** - plate.typ must choose which component to call
+
+---
+
+## Proposed Design
+
+### Option A: Unified `content_grid` with Structured Input
+
+A single component that accepts pre-parsed items from the Quillmark engine.
+
+```typst
+#let content_grid(
+  items: (),
+  columns: 2,
+  style: "auto",  // "auto" | "categorized" | "flat"
+) = {
+  // Detect style from item shape if "auto"
+  let resolved_style = if style == "auto" {
+    if items.len() > 0 and type(items.at(0)) == dictionary {
+      "categorized"
+    } else {
+      "flat"
+    }
+  } else {
+    style
+  }
+
+  vgap(config.entry_spacing)
+
+  let render_cell(item) = {
+    if resolved_style == "categorized" {
+      block({
+        text(weight: "bold", item.key)
+        linebreak()
+        item.value
+      })
+    } else {
+      item
+    }
+  }
+
+  grid(
+    columns: (1fr,) * columns,
+    row-gutter: if resolved_style == "categorized" {
+      config.leading + config.entry_spacing
+    } else {
+      config.leading
+    },
+    column-gutter: 1em,
+    ..items.map(render_cell)
+  )
+}
+```
+
+**Usage from plate.typ:**
+
+```typst
+// Quillmark provides _grid_items based on BODY parsing
+#content_grid(
+  items: {{ card._grid_items | GridItems }},
+  columns: {{ card.columns | Int | default: 2 }},
+)
+```
+
+**Pros:**
+- Single API surface
+- Auto-detection reduces plate.typ complexity
+- Backwards compatible via explicit `style` parameter
+
+**Cons:**
+- Requires Quillmark to pre-parse BODY into `_grid_items`
+- Magic auto-detection could surprise users
+
+---
+
+### Option B: Native Content with Typst Introspection
+
+Accept raw Typst content and use Typst's introspection to determine rendering.
+
+```typst
+#let content_grid(
+  body: none,
+  columns: 2,
+) = {
+  // This approach requires Typst content introspection
+  // which is limited - we can't easily "peek" at content structure
+
+  // Would need show rules or content inspection APIs
+  // that don't cleanly exist in Typst today
+}
+```
+
+**Verdict:** Not recommended. Typst's content model doesn't support easy structural introspection. Parsing should happen in Quillmark, not Typst.
+
+---
+
+### Option C: Keep Separate Components, Modernize APIs
+
+Retain `category_grid` and `item_grid` but improve their flexibility.
+
+```typst
+// Enhanced category_grid - variable item count, optional values
+#let category_grid(
+  items: (),
+  columns: 2,
+  show_keys: true,
+) = {
+  vgap(config.entry_spacing)
+
+  let cell(item) = {
+    block({
+      if show_keys and "key" in item {
+        text(weight: "bold", item.key)
+        linebreak()
+      }
+      if "value" in item {
+        item.value
+      } else if "content" in item {
+        item.content
+      }
+    })
+  }
+
+  grid(
+    columns: (1fr,) * columns,
+    row-gutter: config.leading + config.entry_spacing,
+    column-gutter: 1em,
+    ..items.map(cell)
+  )
+}
+
+// Enhanced item_grid - accepts content or strings
+#let item_grid(
+  items: (),
+  columns: 2,
+  bullet: none,  // Optional bullet prefix
+) = {
+  vgap(config.entry_spacing)
+
+  let cell(item) = {
+    if bullet != none {
+      [#bullet #item]
+    } else {
+      item
+    }
+  }
+
+  grid(
+    columns: (1fr,) * columns,
+    row-gutter: config.leading,
+    column-gutter: 1em,
+    ..items.map(cell)
+  )
+}
+```
+
+**Pros:**
+- Explicit, no magic
+- Easier to understand and debug
+- plate.typ logic remains clear
+
+**Cons:**
+- Two components to maintain
+- plate.typ still needs conditional logic
+
+---
+
+## Recommendation
+
+**Option A (Unified `content_grid`)** with explicit `style` parameter.
+
+The auto-detection is a convenience, but callers can always specify `style: "categorized"` or `style: "flat"` explicitly. This gives us:
+
+1. Single component to maintain
+2. Consistent API for plate.typ
+3. Flexibility for future grid styles (e.g., "compact", "spaced")
+
+---
+
+## Implementation Changes
+
+### File: `src/components.typ`
+
+```typst
+// --- Grid Components ---
+
+// Unified content grid for skills, certifications, and list content
+// Replaces: category_grid, item_grid
+#let content_grid(
+  items: (),
+  columns: 2,
+  style: "auto",  // "auto" | "categorized" | "flat"
+) = {
+  if items.len() == 0 { return }
+
+  // Resolve style from item shape
+  let resolved_style = if style == "auto" {
+    if type(items.at(0)) == dictionary and "key" in items.at(0) {
+      "categorized"
+    } else {
+      "flat"
+    }
+  } else {
+    style
+  }
+
+  vgap(config.entry_spacing)
+
+  let render_cell(item) = {
+    if resolved_style == "categorized" {
+      block({
+        text(weight: "bold", item.key)
+        linebreak()
+        if type(item.value) == content {
+          item.value
+        } else {
+          [#item.value]
+        }
+      })
+    } else {
+      if type(item) == content {
+        item
+      } else {
+        [#item]
+      }
+    }
+  }
+
+  grid(
+    columns: (1fr,) * columns,
+    row-gutter: if resolved_style == "categorized" {
+      config.leading + config.entry_spacing
+    } else {
+      config.leading
+    },
+    column-gutter: 1em,
+    ..items.map(render_cell)
+  )
+}
+
+// Deprecation shims (remove in next major version)
+#let category_grid(items: (), columns: 2) = {
+  content_grid(items: items, columns: columns, style: "categorized")
+}
+
+#let item_grid(items: (), columns: 2) = {
+  content_grid(items: items, columns: columns, style: "flat")
+}
+```
+
+### File: `src/lib.typ`
+
+```typst
+#import "components.typ": (
+  resume_header,
+  section_header,
+  timeline_entry,
+  project_entry,
+  content_grid,
+  // Deprecated but exported for backwards compatibility
+  category_grid,
+  item_grid,
+)
+```
+
+---
+
+## Migration Path
+
+1. **v0.1.x** - Add `content_grid`, keep `category_grid`/`item_grid` as shims
+2. **v0.2.0** - Deprecation warnings in documentation
+3. **v0.3.0** - Remove shims, `content_grid` only
+
+---
+
+## Testing Checklist
+
+- [ ] `content_grid` with categorized items renders correctly
+- [ ] `content_grid` with flat items renders correctly
+- [ ] `style: "auto"` correctly detects item shape
+- [ ] Empty items array renders nothing (no crash)
+- [ ] Columns parameter works for 1, 2, 3, 4 column layouts
+- [ ] Deprecation shims produce identical output to new component
+- [ ] Rich content (links, emphasis) renders in values
+
+---
+
+## Open Questions
+
+1. **Should `style` support additional values?** e.g., `"compact"` for tighter spacing
+2. **Should we support mixed items?** (some categorized, some flat in same grid)
+3. **Column responsiveness?** Should columns auto-adjust based on content width?


### PR DESCRIPTION
Two proposals for redesigning the skills/certifications cards:

1. typst-ttq-classic-resume-grid.md - Proposes unified content_grid component replacing category_grid and item_grid with auto-detection

2. quill-classic-resume-schema.md - Proposes BODY-centric grid card using markdown headers for categories and bullets for flat lists