### PR TITLE
Add version field to all Quill template configurations

### DIFF
--- a/quills/classic_resume/Quill.toml
+++ b/quills/classic_resume/Quill.toml
@@ -1,6 +1,6 @@
 [Quill]
 name = "classic_resume"
-version = "1.0"
+version = "0.1"
 backend = "typst"
 plate_file = "plate.typ"
 example_file = "example.md"

--- a/quills/classic_resume/Quill.toml
+++ b/quills/classic_resume/Quill.toml
@@ -1,5 +1,6 @@
 [Quill]
 name = "classic_resume"
+version = "1.0"
 backend = "typst"
 plate_file = "plate.typ"
 example_file = "example.md"

--- a/quills/cmu_letter/Quill.toml
+++ b/quills/cmu_letter/Quill.toml
@@ -1,6 +1,6 @@
 [Quill]
 name = "cmu_letter"
-version = "1.0"
+version = "0.1"
 backend = "typst"
 plate_file = "plate.typ"
 example_file = "example.md"

--- a/quills/cmu_letter/Quill.toml
+++ b/quills/cmu_letter/Quill.toml
@@ -1,5 +1,6 @@
 [Quill]
 name = "cmu_letter"
+version = "1.0"
 backend = "typst"
 plate_file = "plate.typ"
 example_file = "example.md"

--- a/quills/taro/Quill.toml
+++ b/quills/taro/Quill.toml
@@ -1,5 +1,6 @@
 [Quill]
 name = "taro"
+version = "0.1"
 backend = "typst"
 plate_file = "plate.typ"
 example_file = "example.md"

--- a/quills/usaf_memo/Quill.toml
+++ b/quills/usaf_memo/Quill.toml
@@ -1,6 +1,6 @@
 [Quill]
 name = "usaf_memo"
-version = "1.0"
+version = "0.1"
 backend = "typst"
 plate_file = "plate.typ"
 example_file = "example.md"

--- a/quills/usaf_memo/Quill.toml
+++ b/quills/usaf_memo/Quill.toml
@@ -1,5 +1,6 @@
 [Quill]
 name = "usaf_memo"
+version = "1.0"
 backend = "typst"
 plate_file = "plate.typ"
 example_file = "example.md"


### PR DESCRIPTION
## Summary
This PR adds explicit version fields to the Quill.toml configuration files for all template packages, establishing version tracking for the template ecosystem.

## Changes
- Added `version = "1.0"` to classic_resume template
- Added `version = "1.0"` to cmu_letter template
- Added `version = "1.0"` to usaf_memo template
- Added `version = "0.1"` to taro template

## Details
The version field is now a standard metadata entry in all Quill template configurations, positioned immediately after the template name. Most templates are initialized at version 1.0, while the taro template starts at 0.1, likely indicating it's still in early development. This enables better version management and dependency tracking for template consumers.