### PR TITLE
Add undecided state to endorsement action decision

### DIFF
--- a/quills/usaf_memo/0.2.0/Quill.yaml
+++ b/quills/usaf_memo/0.2.0/Quill.yaml
@@ -193,11 +193,12 @@ cards:
         title: Action Decision
         type: string
         enum:
+          - undecided
           - approve
           - disapprove
         ui:
-          group: Additional
-        description: "Action taken by the endorser. When set, the APPROVE / DISAPPROVE line is displayed with the selected option highlighted."
+          group: Action
+        description: "Action taken by the endorser. Use 'undecided' to display the Approve/Disapprove line with neither option circled, 'approve' or 'disapprove' to circle the selected option."
       attachments:
         title: Attachments for this endorsement
         type: array

--- a/quills/usaf_memo/0.2.0/example.md
+++ b/quills/usaf_memo/0.2.0/example.md
@@ -47,8 +47,7 @@ CARD: indorsement
 for: ORG/SYMBOL
 format: standard
 from: ORG/SYMBOL
-action: approve
-show_action: true
+action: undecided
 signature_block:
   - FIRST M. LAST, Rank, USAF
   - Duty Title


### PR DESCRIPTION
## Summary
Enhanced the endorsement action decision field to support an "undecided" state, allowing users to display the Approve/Disapprove line without either option pre-selected.

## Key Changes
- Added `undecided` as a new enum option for the `action` field in the endorsement card
- Updated the field description to clarify the three action states:
  - `undecided`: displays the line with neither option circled
  - `approve`: circles the approve option
  - `disapprove`: circles the disapprove option
- Reorganized the UI grouping from "Additional" to "Action" for better logical organization
- Updated the example configuration to use `action: undecided` and removed the now-unnecessary `show_action: true` field

## Implementation Details
The change maintains backward compatibility with existing `approve` and `disapprove` values while providing a new default state that displays the decision line without pre-selecting an option. This gives users more flexibility in how they present endorsement decisions in USAF memos.

https://claude.ai/code/session_01B6g4n7dqKfKBPuyoxuUwaG