### PR TITLE
Update endorser action field UI group from Action to Addressing

### DIFF
--- a/quills/usaf_memo/0.2.0/Quill.yaml
+++ b/quills/usaf_memo/0.2.0/Quill.yaml
@@ -197,7 +197,7 @@ cards:
           - approve
           - disapprove
         ui:
-          group: Action
+          group: Addressing
         description: "Action taken by the endorser. Use 'undecided' to display the Approve/Disapprove line with neither option circled, 'approve' or 'disapprove' to circle the selected option."
       attachments:
         title: Attachments for this endorsement


### PR DESCRIPTION
## Summary
Updated the UI grouping for the endorser action field in the USAF memo Quill configuration to better reflect its purpose in the document structure.

## Changes
- Changed the `group` property of the endorser action field from "Action" to "Addressing"
- This affects how the field is organized and displayed in the UI when users interact with endorsement actions

## Details
The endorser action field (which accepts values like 'undecided', 'approve', or 'disapprove') is now categorized under the "Addressing" group instead of "Action". This organizational change better aligns the field with related addressing elements in the memo template.

https://claude.ai/code/session_01F6gXCbmjZ3bRns6D17v6sF