### PR TITLE
Simplify AF4141 template by removing detailed examples

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tonguetoquill/collection",
-  "version": "0.2.12",
+  "version": "0.2.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tonguetoquill/collection",
-      "version": "0.2.12",
+      "version": "0.2.13",
       "devDependencies": {
         "@quillmark/registry": "^0.6.1",
         "@quillmark/wasm": "^0.41.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tonguetoquill/collection",
-  "version": "0.2.12",
+  "version": "0.2.13",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/nibsbin/tonguetoquill-collection.git"

--- a/templates/af4141.md
+++ b/templates/af4141.md
@@ -6,83 +6,18 @@ name: "LAST, FIRST M."
 unit: "UNIT/SYMBOL"
 # EDIT: Current grade or CCC level (e.g., "SSgt", "GS-12", "3")
 grade: "GRADE"
-# EDIT: Commander's authentication entry — often a commander's name/signature block or "Verified by unit commander"
+# EDIT: Commander's authentication entry
 commanders_auth: ""
 ---
 
-<!-- ═══════════════════════════════════════════════════════════════
-     RECORD OF EXPERIENCE CARDS
-     Each card below becomes one row in the experience table.
-     Page 1 holds up to 16 rows; Page 2 holds up to 21 rows (37 max).
-
-     Required reportable actions include:
-       • Initial/subsequent duty assignment
-       • Written and/or positional upgrade evaluations
-       • Certification events (Mission Ready, Senior Director, etc.)
-       • Downgrade or decertification
-       • PCS/PCA departure
-       • Temporary duty of significant duration
-       • Any other commander-directed entry
-
-     Leave blank any columns that do not apply to a given entry.
-═══════════════════════════════════════════════════════════════ -->
-
-<!-- Example 1: Initial assignment to a unit -->
+<!-- Add one CARD: experience block per row. Duplicate as needed. -->
 ---
 CARD: experience
-date: "15 Jan 25"
-action: "Assigned to 1 ACCS/DOT as Weapons Director"
+date: "1 Jan 25"
+action: "Describe the action or event"
 written_grade: ""
 written_grade_date: ""
 positional_grade: ""
 positional_grade_date: ""
-auth_or_remarks: "Initial assignment"
----
-
-<!-- Example 2: Written upgrade evaluation -->
----
-CARD: experience
-date: "15 Mar 25"
-action: "Completed written upgrade evaluation for 3-Level"
-written_grade: "3"
-written_grade_date: "15 Mar 25"
-positional_grade: ""
-positional_grade_date: ""
-auth_or_remarks: "Per AFMAN 13-1CRCV1"
----
-
-<!-- Example 3: Positional (live-environment) upgrade / certification -->
----
-CARD: experience
-date: "20 Jun 25"
-action: "Certified Mission Ready — positional upgrade"
-written_grade: ""
-written_grade_date: ""
-positional_grade: "4"
-positional_grade_date: "20 Jun 25"
-auth_or_remarks: "SSgt Jones, T.R."
----
-
-<!-- Example 4: Combined written + positional upgrade (both columns filled) -->
----
-CARD: experience
-date: "1 Aug 25"
-action: "Upgrade evaluation — written and positional"
-written_grade: "4"
-written_grade_date: "1 Aug 25"
-positional_grade: "4"
-positional_grade_date: "1 Aug 25"
-auth_or_remarks: "Verified by unit commander"
----
-
-<!-- Example 5: PCS departure — no grade columns needed -->
----
-CARD: experience
-date: "1 Sep 25"
-action: "PCS to 726 ACS/MOC, Tinker AFB OK"
-written_grade: ""
-written_grade_date: ""
-positional_grade: ""
-positional_grade_date: ""
-auth_or_remarks: "Outprocessed 1 ACCS/DOT"
+auth_or_remarks: ""
 ---


### PR DESCRIPTION
## Summary
Streamlined the AF4141 form template by removing extensive inline documentation and example cards, replacing them with a minimal template structure and concise instructions.

## Key Changes
- Removed detailed block comment explaining the experience cards section and reportable actions
- Removed five comprehensive example cards demonstrating various scenarios (initial assignment, written evaluation, positional upgrade, combined upgrade, and PCS departure)
- Simplified the commander's authentication field comment from "often a commander's name/signature block or 'Verified by unit commander'" to just "Commander's authentication entry"
- Replaced examples with a single generic template card and a brief instruction comment ("Add one CARD: experience block per row. Duplicate as needed.")
- Updated the example card to use minimal placeholder values (date: "1 Jan 25", action: "Describe the action or event")

## Rationale
This change reduces template verbosity while maintaining functionality. Users can still reference documentation elsewhere or infer the structure from the single provided template card. The simplified approach makes the template file more maintainable and less cluttered.

https://claude.ai/code/session_015D4C9wuiwMGBe2uz6V2mHo