### PR TITLE
Add overflow protection for experience table rows

### DIFF
--- a/quills/af4141/0.1.0/plate.typ
+++ b/quills/af4141/0.1.0/plate.typ
@@ -24,21 +24,26 @@
 #if "commanders_auth" in data { vals.insert("commonforms_text_p1_116", data.commanders_auth) }
 
 // --- Experience table rows from cards ---
+// The form supports 16 rows on page 1 and 21 rows on page 2 (37 total).
+// Overflow rows are silently ignored.
+#let max-rows = 37
 #{
   let row = 0
   for card in data.CARDS {
     if card.CARD == "experience" {
-      for (col, key) in col-keys.enumerate() {
-        let value = card.at(key, default: "")
-        if value != "" {
-          let field-name = if row < 16 {
-            // Page 1: fields start at index 4, stride 7
-            "commonforms_text_p1_" + str(4 + row * 7 + col)
-          } else {
-            // Page 2: fields start at index 1, stride 7
-            "commonforms_text_p2_" + str(1 + (row - 16) * 7 + col)
+      if row < max-rows {
+        for (col, key) in col-keys.enumerate() {
+          let value = card.at(key, default: "")
+          if value != "" {
+            let field-name = if row < 16 {
+              // Page 1: fields start at index 4, stride 7
+              "commonforms_text_p1_" + str(4 + row * 7 + col)
+            } else {
+              // Page 2: fields start at index 1, stride 7
+              "commonforms_text_p2_" + str(1 + (row - 16) * 7 + col)
+            }
+            vals.insert(field-name, value)
           }
-          vals.insert(field-name, value)
         }
       }
       row = row + 1


### PR DESCRIPTION
## Summary
Added validation to prevent processing experience card rows beyond the maximum supported capacity of the form.

## Key Changes
- Defined `max-rows` constant set to 37 (16 rows on page 1 + 21 rows on page 2) to document the form's capacity
- Added a guard condition `if row < max-rows` to skip processing of overflow experience cards
- Wrapped the column iteration logic inside the new row limit check to ensure excess rows are silently ignored

## Implementation Details
The form has a fixed layout with 16 experience rows on page 1 and 21 rows on page 2, totaling 37 rows. Previously, the code would attempt to process all experience cards without bounds checking, which could lead to undefined behavior or field mapping errors for forms with more than 37 experience entries. The fix ensures that only the first 37 rows are processed, with any additional rows being safely ignored.

https://claude.ai/code/session_01TAbsuyicqeGYmHNYevBGqC