### PR TITLE
Migrate Quill.yaml files to use `main.fields` and `main.ui`

### DIFF
--- a/quills/af4141/0.1.0/Quill.yaml
+++ b/quills/af4141/0.1.0/Quill.yaml
@@ -3,33 +3,34 @@ Quill:
   version: 0.1.0
   backend: typst
   plate_file: plate.typ
-  ui:
-    hide_body: true
   example_file: example.md
   description: "AF Form 4141 — Individual's Record of Duties and Experience, Ground Environment Personnel"
 
-fields:
-  name:
-    title: Name (Last, First, MI)
-    type: string
-    required: true
-    description: Full name in Last, First, Middle Initial format.
+main:
+  ui:
+    hide_body: true
+  fields:
+    name:
+      title: Name (Last, First, MI)
+      type: string
+      required: true
+      description: Full name in Last, First, Middle Initial format.
 
-  unit:
-    title: Unit of Assignment
-    type: string
-    required: true
-    description: Unit or organization of assignment.
+    unit:
+      title: Unit of Assignment
+      type: string
+      required: true
+      description: Unit or organization of assignment.
 
-  grade:
-    title: Grade/CCC Level
-    type: string
-    description: Current grade or CCC level.
+    grade:
+      title: Grade/CCC Level
+      type: string
+      description: Current grade or CCC level.
 
-  commanders_auth:
-    title: Commander's Record of Authentication
-    type: string
-    description: Commander's authentication entry on page 1.
+    commanders_auth:
+      title: Commander's Record of Authentication
+      type: string
+      description: Commander's authentication entry on page 1.
 
 cards:
   experience:

--- a/quills/classic_resume/0.1.0/Quill.yaml
+++ b/quills/classic_resume/0.1.0/Quill.yaml
@@ -6,27 +6,28 @@ Quill:
   example_file: example.md
   description: A clean and modern classic resume template.
 
-fields:
-  name:
-    title: Full Name
-    type: string
-    required: true
-    examples:
-      - John Doe
-    ui:
-      group: Personal Info
+main:
+  fields:
+    name:
+      title: Full Name
+      type: string
+      required: true
+      examples:
+        - John Doe
+      ui:
+        group: Personal Info
 
-  contacts:
-    title: Contact Information
-    type: array
-    required: true
-    examples:
-      - - john.doe@example.com
-        - 123-456-7890
-        - linkedin.com/in/johndoe
-    ui:
-      group: Personal Info
-    description: List of contact details (email, phone, links, etc.)
+    contacts:
+      title: Contact Information
+      type: array
+      required: true
+      examples:
+        - - john.doe@example.com
+          - 123-456-7890
+          - linkedin.com/in/johndoe
+      ui:
+        group: Personal Info
+      description: List of contact details (email, phone, links, etc.)
 
 cards:
   experience_section:

--- a/quills/cmu_letter/0.1.0/Quill.yaml
+++ b/quills/cmu_letter/0.1.0/Quill.yaml
@@ -6,59 +6,60 @@ Quill:
   example_file: example.md
   description: Typeset letters that comply with Carnegie Mellon University letterhead standards.
 
-fields:
-  recipient:
-    title: Recipient's name and address
-    type: array
-    examples:
-      - - Mr. John Doe
-        - 123 Main St
-        - Anytown, USA
-    ui:
-      group: Essentials
-    description: The recipient's name and full mailing address.
+main:
+  fields:
+    recipient:
+      title: Recipient's name and address
+      type: array
+      examples:
+        - - Mr. John Doe
+          - 123 Main St
+          - Anytown, USA
+      ui:
+        group: Essentials
+      description: The recipient's name and full mailing address.
 
-  signature_block:
-    title: Signature block lines
-    type: array
-    examples:
-      - - First M. Last
-        - Title
-    ui:
-      group: Essentials
-    description: "The signer's information. Line 1: Name. Line 2: Title."
+    signature_block:
+      title: Signature block lines
+      type: array
+      examples:
+        - - First M. Last
+          - Title
+      ui:
+        group: Essentials
+      description: "The signer's information. Line 1: Name. Line 2: Title."
 
-  department:
-    title: Name of the department or unit
-    type: string
-    examples:
-      - Department of Electrical and Computer Engineering
-    ui:
-      group: Letterhead
-    description: The department or organizational unit name for the letterhead.
+    department:
+      title: Name of the department or unit
+      type: string
+      examples:
+        - Department of Electrical and Computer Engineering
+      ui:
+        group: Letterhead
+      description: The department or organizational unit name for the letterhead.
 
-  address:
-    title: Sender's address lines
-    type: array
-    examples:
-      - - 5000 Forbes Avenue
-        - Pittsburgh, PA 15213-3890
-    ui:
-      group: Letterhead
-    description: The sender's institutional mailing address.
+    address:
+      title: Sender's address lines
+      type: array
+      examples:
+        - - 5000 Forbes Avenue
+          - Pittsburgh, PA 15213-3890
+      ui:
+        group: Letterhead
+      description: The sender's institutional mailing address.
 
-  url:
-    title: Department or university URL
-    type: string
-    examples:
-      - www.ece.cmu.edu
-    ui:
-      group: Letterhead
-    description: The department or university website URL.
+    url:
+      title: Department or university URL
+      type: string
+      examples:
+        - www.ece.cmu.edu
+      ui:
+        group: Letterhead
+      description: The department or university website URL.
 
-  date:
-    title: Date of the letter
-    type: date
-    ui:
-      group: Advanced
-    description: The date to appear on the letter.
+    date:
+      title: Date of the letter
+      type: date
+      ui:
+        group: Advanced
+      description: The date to appear on the letter.

--- a/quills/daf4392/0.1.0/Quill.yaml
+++ b/quills/daf4392/0.1.0/Quill.yaml
@@ -3,80 +3,81 @@ Quill:
   version: 0.1.0
   backend: typst
   plate_file: plate.typ
-  ui:
-    hide_body: true
   example_file: example.md
   description: "DAF Form 4392 - Pre-Departure Safety Briefing (Page 2)"
 
-fields:
-  transportation_mode:
-    title: Mode of Transportation
-    type: string
-    enum: [pmv, airplane, bus, train, motorcycle, other]
-    required: true
-    description: "Matches the check box."
+main:
+  ui:
+    hide_body: true
+  fields:
+    transportation_mode:
+      title: Mode of Transportation
+      type: string
+      enum: [pmv, airplane, bus, train, motorcycle, other]
+      required: true
+      description: "Matches the check box."
 
-  departure_date:
-    title: Departure Date
-    type: date
-    required: true
-    ui:
-      compact: true
-    description: "Date of initial departure."
+    departure_date:
+      title: Departure Date
+      type: date
+      required: true
+      ui:
+        compact: true
+      description: "Date of initial departure."
 
-  final_destination:
-    title: Final Destination
-    type: string
-    required: true
-    ui:
-      compact: true
-    description: "Final travel destination."
+    final_destination:
+      title: Final Destination
+      type: string
+      required: true
+      ui:
+        compact: true
+      description: "Final travel destination."
 
-  notes:
-    title: Notes
-    type: string
-    description: "Additional notes or remarks for the travel."
+    notes:
+      title: Notes
+      type: string
+      description: "Additional notes or remarks for the travel."
 
-  organization:
-    title: Organization
-    type: string
-    required: true
-    ui:
-      compact: true
-    description: "Unit / Organization conducting the brief."
+    organization:
+      title: Organization
+      type: string
+      required: true
+      ui:
+        compact: true
+      description: "Unit / Organization conducting the brief."
 
-  briefed_date:
-    title: Date Briefed
-    type: date
-    required: true
-    ui:
-      compact: true
-    description: "Date the brief took place."
+    briefed_date:
+      title: Date Briefed
+      type: date
+      required: true
+      ui:
+        compact: true
+      description: "Date the brief took place."
 
-  briefee_name:
-    title: Individual Receiving Brief (Name)
-    type: string
-    required: true
-    ui:
-      compact: true
-    description: "Name (Last, First) of the individual receiving the brief."
+    briefee_name:
+      title: Individual Receiving Brief (Name)
+      type: string
+      required: true
+      ui:
+        compact: true
+      description: "Name (Last, First) of the individual receiving the brief."
 
-  briefee_grade:
-    title: Individual Receiving Brief (Grade)
-    type: string
-    ui:
-      compact: true
-    description: "Grade of the individual receiving the brief."
+    briefee_grade:
+      title: Individual Receiving Brief (Grade)
+      type: string
+      ui:
+        compact: true
+      description: "Grade of the individual receiving the brief."
 
-  emergency_contact_name:
-    title: Emergency Contact Name
-    type: string
-    description: "Name of the emergency contact person at the bottom of the form."
+    emergency_contact_name:
+      title: Emergency Contact Name
+      type: string
+      description: "Name of the emergency contact person at the bottom of the form."
 
-  emergency_contact_phone:
-    title: Emergency Contact Phone
-    type: string
-    description: "Phone number of the emergency contact person at the bottom of the form."
+    emergency_contact_phone:
+      title: Emergency Contact Phone
+      type: string
+      description: "Phone number of the emergency contact person at the bottom of the form."
 
 cards:
   itinerary:

--- a/quills/taro/0.1.0/Quill.yaml
+++ b/quills/taro/0.1.0/Quill.yaml
@@ -6,17 +6,18 @@ Quill:
   example_file: example.md
   description: A simple document template for testing
 
-fields:
-  author:
-    title: Author of document
-    type: string
-  ice_cream:
-    title: favorite ice cream flavor
-    type: string
-    default: taro
-  title:
-    title: title of document
-    type: string
+main:
+  fields:
+    author:
+      title: Author of document
+      type: string
+    ice_cream:
+      title: favorite ice cream flavor
+      type: string
+      default: taro
+    title:
+      title: title of document
+      type: string
 
 cards:
   quotes:

--- a/quills/usaf_memo/0.1.0/Quill.yaml
+++ b/quills/usaf_memo/0.1.0/Quill.yaml
@@ -6,145 +6,146 @@ Quill:
   example_file: example.md
   description: Typesetted USAF Official Memorandum
 
-fields:
-  memo_for:
-    title: List of recipient organization(s)
-    type: array
-    required: true
-    examples:
-      - - ORG1/SYMBOL
-        - ORG2/SYMBOL
-    ui:
-      group: Addressing
-    description: "Organization/office symbol in UPPERCASE. To address a specific person, add their rank and name in parentheses (e.g., 'ORG/SYMBOL (LT COL JANE DOE)'). For numerous recipients, use 'DISTRIBUTION'."
+main:
+  fields:
+    memo_for:
+      title: List of recipient organization(s)
+      type: array
+      required: true
+      examples:
+        - - ORG1/SYMBOL
+          - ORG2/SYMBOL
+      ui:
+        group: Addressing
+      description: "Organization/office symbol in UPPERCASE. To address a specific person, add their rank and name in parentheses (e.g., 'ORG/SYMBOL (LT COL JANE DOE)'). For numerous recipients, use 'DISTRIBUTION'."
 
-  memo_from:
-    title: "Sender information as array: [ORG/SYMBOL, 'Organization Name', 'Street Address', 'City State ZIP']"
-    type: array
-    required: true
-    examples:
-      - - ORG/SYMBOL
-        - Organization Name
-        - 123 Street Ave
-        - City ST 12345-6789
-    ui:
-      group: Addressing
-    description: If recipients are on the same installation, use only the office symbol. For recipients on other installations, include the full mailing address to enable return correspondence.
+    memo_from:
+      title: "Sender information as array: [ORG/SYMBOL, 'Organization Name', 'Street Address', 'City State ZIP']"
+      type: array
+      required: true
+      examples:
+        - - ORG/SYMBOL
+          - Organization Name
+          - 123 Street Ave
+          - City ST 12345-6789
+      ui:
+        group: Addressing
+      description: If recipients are on the same installation, use only the office symbol. For recipients on other installations, include the full mailing address to enable return correspondence.
 
-  subject:
-    title: Subject of the memo
-    type: string
-    required: true
-    examples:
-      - Subject of the Memorandum
-    ui:
-      group: Addressing
-    description: Be brief and clear. Capitalize the first letter of each word except articles, prepositions, and conjunctions. Include suspense dates in parentheses if applicable.
+    subject:
+      title: Subject of the memo
+      type: string
+      required: true
+      examples:
+        - Subject of the Memorandum
+      ui:
+        group: Addressing
+      description: Be brief and clear. Capitalize the first letter of each word except articles, prepositions, and conjunctions. Include suspense dates in parentheses if applicable.
 
-  signature_block:
-    title: Signature block lines
-    type: array
-    required: true
-    examples:
-      - - "FIRST M. LAST, Rank, USSF"
-        - Duty Title
-    ui:
-      group: Addressing
-    description: "Line 1: Name in UPPERCASE as signed, grade, and service. Line 2: Duty title. Spell out 'Colonel' and general officer ranks."
+    signature_block:
+      title: Signature block lines
+      type: array
+      required: true
+      examples:
+        - - "FIRST M. LAST, Rank, USSF"
+          - Duty Title
+      ui:
+        group: Addressing
+      description: "Line 1: Name in UPPERCASE as signed, grade, and service. Line 2: Duty title. Spell out 'Colonel' and general officer ranks."
 
-  letterhead_title:
-    title: Title in letterhead
-    type: string
-    default: DEPARTMENT OF THE AIR FORCE
-    ui:
-      group: Letterhead
-    description: Standard title. Only change for Joint Commands or DoW Agencies.
+    letterhead_title:
+      title: Title in letterhead
+      type: string
+      default: DEPARTMENT OF THE AIR FORCE
+      ui:
+        group: Letterhead
+      description: Standard title. Only change for Joint Commands or DoW Agencies.
 
-  letterhead_caption:
-    title: Letterhead caption line(s)
-    type: array
-    default:
-      - HEADQUARTERS [UNIT NAME]
-    ui:
-      group: Letterhead
-    description: The full organization name of your unit.
+    letterhead_caption:
+      title: Letterhead caption line(s)
+      type: array
+      default:
+        - HEADQUARTERS [UNIT NAME]
+      ui:
+        group: Letterhead
+      description: The full organization name of your unit.
 
-  tag_line:
-    title: Tag line at bottom of memo
-    type: string
-    default: ""
-    ui:
-      group: Letterhead
-    description: Organizational motto at the bottom of the page.
+    tag_line:
+      title: Tag line at bottom of memo
+      type: string
+      default: ""
+      ui:
+        group: Letterhead
+      description: Organizational motto at the bottom of the page.
 
-  date:
-    title: Date of memo (YYYY-MM-DD); defaults to today
-    type: string
-    default: ""
-    ui:
-      group: Additional
-    description: YYYY-MM-DD. Leave blank to use today's date.
+    date:
+      title: Date of memo (YYYY-MM-DD); defaults to today
+      type: string
+      default: ""
+      ui:
+        group: Additional
+      description: YYYY-MM-DD. Leave blank to use today's date.
 
-  references:
-    title: References for the memo
-    type: array
-    default: []
-    examples:
-      - - "AFM 33-326, 31 July 2019, Preparing Official Communications"
-    ui:
-      group: Additional
-    description: "Cite by organization, type, date, and title."
+    references:
+      title: References for the memo
+      type: array
+      default: []
+      examples:
+        - - "AFM 33-326, 31 July 2019, Preparing Official Communications"
+      ui:
+        group: Additional
+      description: "Cite by organization, type, date, and title."
 
-  cc:
-    title: Carbon copy recipients
-    type: array
-    default: []
-    examples:
-      - - Rank and Name, ORG/SYMBOL
-    ui:
-      group: Additional
-    description: List office symbols of recipients to receive copies.
+    cc:
+      title: Carbon copy recipients
+      type: array
+      default: []
+      examples:
+        - - Rank and Name, ORG/SYMBOL
+      ui:
+        group: Additional
+      description: List office symbols of recipients to receive copies.
 
-  distribution:
-    title: Distribution list. Used when "SEE DISTRIBUTION" is specified in `memo_for`.
-    type: array
-    default: []
-    examples:
-      - - ORG1/SYMBOL
-        - ORG2/SYMBOL
-    ui:
-      group: Additional
-    description: Complete list of recipients if 'SEE DISTRIBUTION' is used in the 'Memo For' field.
+    distribution:
+      title: Distribution list. Used when "SEE DISTRIBUTION" is specified in `memo_for`.
+      type: array
+      default: []
+      examples:
+        - - ORG1/SYMBOL
+          - ORG2/SYMBOL
+      ui:
+        group: Additional
+      description: Complete list of recipients if 'SEE DISTRIBUTION' is used in the 'Memo For' field.
 
-  attachments:
-    title: List of attachments
-    type: array
-    default: []
-    examples:
-      - - Attachment description, YYYY MMM DD
-    ui:
-      group: Additional
-    description: List attachments in the order they are mentioned in the memo. Briefly describe each; do not use 'as stated' or abbreviations.
+    attachments:
+      title: List of attachments
+      type: array
+      default: []
+      examples:
+        - - Attachment description, YYYY MMM DD
+      ui:
+        group: Additional
+      description: List attachments in the order they are mentioned in the memo. Briefly describe each; do not use 'as stated' or abbreviations.
 
-  classification:
-    title: Classification level of the memo that displays in the banner
-    type: string
-    default: ""
-    examples:
-      - CONFIDENTIAL
-    ui:
-      group: Additional
-    description: Follow AFI 31-401 and applicable DoD guidance for classification markings. Leave blank for unclassified.
+    classification:
+      title: Classification level of the memo that displays in the banner
+      type: string
+      default: ""
+      examples:
+        - CONFIDENTIAL
+      ui:
+        group: Additional
+      description: Follow AFI 31-401 and applicable DoD guidance for classification markings. Leave blank for unclassified.
 
-  font_size:
-    title: Font size for the memo text (int pt)
-    type: number
-    default: 11
-    examples:
-      - 11
-    ui:
-      group: Additional
-    description: Font size for the memo text (pt).
+    font_size:
+      title: Font size for the memo text (int pt)
+      type: number
+      default: 11
+      examples:
+        - 11
+      ui:
+        group: Additional
+      description: Font size for the memo text (pt).
 
 cards:
   indorsement:

--- a/quills/usaf_memo/0.2.0/Quill.yaml
+++ b/quills/usaf_memo/0.2.0/Quill.yaml
@@ -6,145 +6,146 @@ Quill:
   example_file: example.md
   description: Typesetted USAF Official Memorandum
 
-fields:
-  memo_for:
-    title: List of recipient organization(s)
-    type: array
-    required: true
-    examples:
-      - - ORG1/SYMBOL
-        - ORG2/SYMBOL
-    ui:
-      group: Addressing
-    description: "Organization/office symbol in UPPERCASE. To address a specific person, add their rank and name in parentheses (e.g., 'ORG/SYMBOL (LT COL JANE DOE)'). For numerous recipients, use 'DISTRIBUTION'."
+main:
+  fields:
+    memo_for:
+      title: List of recipient organization(s)
+      type: array
+      required: true
+      examples:
+        - - ORG1/SYMBOL
+          - ORG2/SYMBOL
+      ui:
+        group: Addressing
+      description: "Organization/office symbol in UPPERCASE. To address a specific person, add their rank and name in parentheses (e.g., 'ORG/SYMBOL (LT COL JANE DOE)'). For numerous recipients, use 'DISTRIBUTION'."
 
-  memo_from:
-    title: "Sender information as array: [ORG/SYMBOL, 'Organization Name', 'Street Address', 'City State ZIP']"
-    type: array
-    required: true
-    examples:
-      - - ORG/SYMBOL
-        - Organization Name
-        - 123 Street Ave
-        - City ST 12345-6789
-    ui:
-      group: Addressing
-    description: If recipients are on the same installation, use only the office symbol. For recipients on other installations, include the full mailing address to enable return correspondence.
+    memo_from:
+      title: "Sender information as array: [ORG/SYMBOL, 'Organization Name', 'Street Address', 'City State ZIP']"
+      type: array
+      required: true
+      examples:
+        - - ORG/SYMBOL
+          - Organization Name
+          - 123 Street Ave
+          - City ST 12345-6789
+      ui:
+        group: Addressing
+      description: If recipients are on the same installation, use only the office symbol. For recipients on other installations, include the full mailing address to enable return correspondence.
 
-  subject:
-    title: Subject of the memo
-    type: string
-    required: true
-    examples:
-      - Subject of the Memorandum
-    ui:
-      group: Addressing
-    description: Be brief and clear. Capitalize the first letter of each word except articles, prepositions, and conjunctions. Include suspense dates in parentheses if applicable.
+    subject:
+      title: Subject of the memo
+      type: string
+      required: true
+      examples:
+        - Subject of the Memorandum
+      ui:
+        group: Addressing
+      description: Be brief and clear. Capitalize the first letter of each word except articles, prepositions, and conjunctions. Include suspense dates in parentheses if applicable.
 
-  signature_block:
-    title: Signature block lines
-    type: array
-    required: true
-    examples:
-      - - "FIRST M. LAST, Rank, USSF"
-        - Duty Title
-    ui:
-      group: Addressing
-    description: "Line 1: Name in UPPERCASE as signed, grade, and service. Line 2: Duty title. Spell out 'Colonel' and general officer ranks."
+    signature_block:
+      title: Signature block lines
+      type: array
+      required: true
+      examples:
+        - - "FIRST M. LAST, Rank, USSF"
+          - Duty Title
+      ui:
+        group: Addressing
+      description: "Line 1: Name in UPPERCASE as signed, grade, and service. Line 2: Duty title. Spell out 'Colonel' and general officer ranks."
 
-  letterhead_title:
-    title: Title in letterhead
-    type: string
-    default: DEPARTMENT OF THE AIR FORCE
-    ui:
-      group: Letterhead
-    description: Standard title. Only change for Joint Commands or DoW Agencies.
+    letterhead_title:
+      title: Title in letterhead
+      type: string
+      default: DEPARTMENT OF THE AIR FORCE
+      ui:
+        group: Letterhead
+      description: Standard title. Only change for Joint Commands or DoW Agencies.
 
-  letterhead_caption:
-    title: Letterhead caption line(s)
-    type: array
-    default:
-      - HEADQUARTERS [UNIT NAME]
-    ui:
-      group: Letterhead
-    description: The full organization name of your unit.
+    letterhead_caption:
+      title: Letterhead caption line(s)
+      type: array
+      default:
+        - HEADQUARTERS [UNIT NAME]
+      ui:
+        group: Letterhead
+      description: The full organization name of your unit.
 
-  tag_line:
-    title: Tag line at bottom of memo
-    type: string
-    default: ""
-    ui:
-      group: Letterhead
-    description: Organizational motto at the bottom of the page.
+    tag_line:
+      title: Tag line at bottom of memo
+      type: string
+      default: ""
+      ui:
+        group: Letterhead
+      description: Organizational motto at the bottom of the page.
 
-  date:
-    title: Date of memo (YYYY-MM-DD); defaults to today
-    type: string
-    default: ""
-    ui:
-      group: Additional
-    description: YYYY-MM-DD. Leave blank to use today's date.
+    date:
+      title: Date of memo (YYYY-MM-DD); defaults to today
+      type: string
+      default: ""
+      ui:
+        group: Additional
+      description: YYYY-MM-DD. Leave blank to use today's date.
 
-  references:
-    title: References for the memo
-    type: array
-    default: []
-    examples:
-      - - "AFM 33-326, 31 July 2019, Preparing Official Communications"
-    ui:
-      group: Additional
-    description: "Cite by organization, type, date, and title."
+    references:
+      title: References for the memo
+      type: array
+      default: []
+      examples:
+        - - "AFM 33-326, 31 July 2019, Preparing Official Communications"
+      ui:
+        group: Additional
+      description: "Cite by organization, type, date, and title."
 
-  cc:
-    title: Carbon copy recipients
-    type: array
-    default: []
-    examples:
-      - - Rank and Name, ORG/SYMBOL
-    ui:
-      group: Additional
-    description: List office symbols of recipients to receive copies.
+    cc:
+      title: Carbon copy recipients
+      type: array
+      default: []
+      examples:
+        - - Rank and Name, ORG/SYMBOL
+      ui:
+        group: Additional
+      description: List office symbols of recipients to receive copies.
 
-  distribution:
-    title: Distribution list. Used when "SEE DISTRIBUTION" is specified in `memo_for`.
-    type: array
-    default: []
-    examples:
-      - - ORG1/SYMBOL
-        - ORG2/SYMBOL
-    ui:
-      group: Additional
-    description: Complete list of recipients if 'SEE DISTRIBUTION' is used in the 'Memo For' field.
+    distribution:
+      title: Distribution list. Used when "SEE DISTRIBUTION" is specified in `memo_for`.
+      type: array
+      default: []
+      examples:
+        - - ORG1/SYMBOL
+          - ORG2/SYMBOL
+      ui:
+        group: Additional
+      description: Complete list of recipients if 'SEE DISTRIBUTION' is used in the 'Memo For' field.
 
-  attachments:
-    title: List of attachments
-    type: array
-    default: []
-    examples:
-      - - Attachment description, YYYY MMM DD
-    ui:
-      group: Additional
-    description: List attachments in the order they are mentioned in the memo. Briefly describe each; do not use 'as stated' or abbreviations.
+    attachments:
+      title: List of attachments
+      type: array
+      default: []
+      examples:
+        - - Attachment description, YYYY MMM DD
+      ui:
+        group: Additional
+      description: List attachments in the order they are mentioned in the memo. Briefly describe each; do not use 'as stated' or abbreviations.
 
-  classification:
-    title: Classification level of the memo that displays in the banner
-    type: string
-    default: ""
-    examples:
-      - CONFIDENTIAL
-    ui:
-      group: Additional
-    description: Follow AFI 31-401 and applicable DoD guidance for classification markings. Leave blank for unclassified.
+    classification:
+      title: Classification level of the memo that displays in the banner
+      type: string
+      default: ""
+      examples:
+        - CONFIDENTIAL
+      ui:
+        group: Additional
+      description: Follow AFI 31-401 and applicable DoD guidance for classification markings. Leave blank for unclassified.
 
-  font_size:
-    title: Font size for the memo text (int pt)
-    type: number
-    default: 11
-    examples:
-      - 11
-    ui:
-      group: Additional
-    description: Font size for the memo text (pt).
+    font_size:
+      title: Font size for the memo text (int pt)
+      type: number
+      default: 11
+      examples:
+        - 11
+      ui:
+        group: Additional
+      description: Font size for the memo text (pt).
 
 cards:
   indorsement:


### PR DESCRIPTION
### Motivation
- The Quill schema now treats the primary document as an explicit `main` card instead of a root-level `fields:` block, and document-level UI belongs under `main.ui`. 
- This change unifies schema shape across quills and avoids ambiguity between root `fields:` and card `cards:` definitions.

### Description
- Moved legacy root-level `fields:` blocks into `main.fields:` across all quill definitions under `quills/*/*/Quill.yaml`. 
- Moved document-level UI settings previously in `Quill.ui` into `main.ui` where present. 
- Kept all named reusable `cards:` entries unchanged and preserved existing field metadata and UI subkeys.

### Testing
- Ran the migration script using `python3` to transform each `Quill.yaml` file and the operation completed successfully. 
- Confirmed no remaining root-level `fields:` blocks and no `Quill.ui` keys in the migrated files using `rg` and a Python validation check. 
- Attempted to run `quillmark validate quills` but the `quillmark` command is not available in this environment, so schema validation could not be performed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c9cb25523c8323a3c284b1365d8450)