### PR TITLE
Standardize field naming to snake_case across DAF1206

### DIFF
--- a/quills/daf1206/0.1.0/Quill.yaml
+++ b/quills/daf1206/0.1.0/Quill.yaml
@@ -10,42 +10,42 @@ main:
   ui:
     hide_body: true
   fields:
-    AWARD:
+    award:
       title: Award
       type: string
       required: true
-    CATEGORY:
+    category:
       title: Category (If Applicable)
       type: string
-    AWARD_PERIOD:
+    award_period:
       title: Award Period
       type: string
       required: true
-    RANKNAME_OF_NOMINEE:
+    rankname_of_nominee:
       title: Rank/Name of Nominee (First, Middle Initial, Last)
       type: string
       required: true
-    MAJCOM_FLDCOM_FOA_OR_DRU:
+    majcom_fldcom_foa_or_dru:
       title: MAJCOM/FLDCOM/FOA/DRU
       type: string
-    DAFSCDUTY_TITLE:
+    dafscduty_title:
       title: DAFSC/Duty Title
       type: string
-    NOMINEES_TELEPHONE:
+    nominees_telephone:
       title: Nominee's Telephone (DSN/Commercial)
       type: string
-    UNITOFFICE_SYMBOL:
+    unitoffice_symbol:
       title: Unit/Office Symbol/Street Address/Base/State/Zip Code
       type: string
-    UNIT_COMMANDER:
+    unit_commander:
       title: Rank/Name of Unit Commander & Telephone
       type: string
-    ACCOMPLISHMENTS:
+    accomplishments:
       title: Specific Accomplishments (Page 1)
       type: string
       ui:
         multiline: true
-    ACCOMPLISHMENTS_CONTINUED:
+    accomplishments_continued:
       title: Specific Accomplishments (Continued - Page 2)
       type: string
       ui:

--- a/quills/daf1206/0.1.0/example.md
+++ b/quills/daf1206/0.1.0/example.md
@@ -1,19 +1,19 @@
 ---
 QUILL: daf1206@0.1.0
-AWARD: "AIR AND SPACE ACHIEVEMENT MEDAL"
-CATEGORY: "asdfasdfasdf"
-AWARD_PERIOD: "1 Jan 24 - 31 Dec 24 asdfasdfasdf"
-RANKNAME_OF_NOMINEE: "SSgt Doe, John A."
-MAJCOM_FLDCOM_FOA_OR_DRU: "ACC"
-DAFSCDUTY_TITLE: "1D7X1 / Cyber Operator"
-NOMINEES_TELEPHONE: "DSN: 123-4567 / Comm: (123) 456-7890"
-UNITOFFICE_SYMBOL: "1st Communications Squadron / SC, 123 Main St, AFB, ST 12345"
-UNIT_COMMANDER: "Capt Jane Smith / DSN: 123-4568 / Comm: (123) 456-7891"
+award: "AIR AND SPACE ACHIEVEMENT MEDAL"
+category: "asdfasdfasdf"
+award_period: "1 Jan 24 - 31 Dec 24 asdfasdfasdf"
+rankname_of_nominee: "SSgt Doe, John A."
+majcom_fldcom_foa_or_dru: "ACC"
+dafscduty_title: "1D7X1 / Cyber Operator"
+nominees_telephone: "DSN: 123-4567 / Comm: (123) 456-7890"
+unitoffice_symbol: "1st Communications Squadron / SC, 123 Main St, AFB, ST 12345"
+unit_commander: "Capt Jane Smith / DSN: 123-4568 / Comm: (123) 456-7891"
 
-ACCOMPLISHMENTS: |-
+accomplishments: |-
   - Spearheaded major network upgrade; improved speed by 50%
   - Mentored 5 Airmen; 100% upgrade training completion rate
 
-ACCOMPLISHMENTS_CONTINUED: |-
+accomplishments_continued: |-
   - Continued excellence in supporting base communications
 ---

--- a/quills/daf1206/0.1.0/packages/typst-daf1206/FIELDS.json
+++ b/quills/daf1206/0.1.0/packages/typst-daf1206/FIELDS.json
@@ -11,7 +11,7 @@
   ],
   "fields": [
     {
-      "name": "AWARD",
+      "name": "award",
       "type": "text",
       "bbox": [
         21.479999542236328,
@@ -23,7 +23,7 @@
       "options": null
     },
     {
-      "name": "CATEGORY If Applicable",
+      "name": "category",
       "type": "text",
       "bbox": [
         309.1199951171875,
@@ -35,7 +35,7 @@
       "options": null
     },
     {
-      "name": "AWARD PERIOD",
+      "name": "award_period",
       "type": "text",
       "bbox": [
         424.9200134277344,
@@ -47,7 +47,7 @@
       "options": null
     },
     {
-      "name": "RANKNAME OF NOMINEE First Middle Initial Last",
+      "name": "rankname_of_nominee",
       "type": "text",
       "bbox": [
         21.360000610351562,
@@ -59,7 +59,7 @@
       "options": null
     },
     {
-      "name": "MAJCOM FLDCOM FOA OR DRU",
+      "name": "majcom_fldcom_foa_or_dru",
       "type": "text",
       "bbox": [
         350.1600036621094,
@@ -71,7 +71,7 @@
       "options": null
     },
     {
-      "name": "DAFSCDUTY TITLE",
+      "name": "dafscduty_title",
       "type": "text",
       "bbox": [
         21.479999542236328,
@@ -83,7 +83,7 @@
       "options": null
     },
     {
-      "name": "NOMINEES TELEPHONE  DSN  Commercial",
+      "name": "nominees_telephone",
       "type": "text",
       "bbox": [
         288.4800109863281,
@@ -95,7 +95,7 @@
       "options": null
     },
     {
-      "name": "UNITOFFICE SYMBOLSTREET ADDRESSBASESTATEZIP CODE",
+      "name": "unitoffice_symbol",
       "type": "text",
       "bbox": [
         21.360000610351562,
@@ -107,7 +107,7 @@
       "options": null
     },
     {
-      "name": "RANKNAME OF UNIT COMMANDER First Middle Initial LastCOMMANDERS TELEPHONE DSN  Commercial",
+      "name": "unit_commander",
       "type": "text",
       "bbox": [
         21.479999542236328,
@@ -119,7 +119,7 @@
       "options": null
     },
     {
-      "name": "SPECIFIC ACCOMPLISHMENTS Use Performance Statements IAW DAFMAN 362806",
+      "name": "accomplishments",
       "type": "text",
       "bbox": [
         22.079999923706055,
@@ -131,7 +131,7 @@
       "options": null
     },
     {
-      "name": "RANKNAME OF NOMINEE First Middle Initial Last_2",
+      "name": "rankname_of_nominee_2",
       "type": "text",
       "bbox": [
         21.479999542236328,
@@ -143,7 +143,7 @@
       "options": null
     },
     {
-      "name": "SPECIFIC ACCOMPLISHMENTS Use Performance Statements IAW DAFMAN 362806 Continued",
+      "name": "accomplishments_continued",
       "type": "text",
       "bbox": [
         22.079999923706055,

--- a/quills/daf1206/0.1.0/packages/typst-daf1206/form.typ
+++ b/quills/daf1206/0.1.0/packages/typst-daf1206/form.typ
@@ -3,34 +3,34 @@
 
 #let form(
   debug: false,
-  AWARD: "",  // text
-  CATEGORY_If_Applicable: "",  // text
-  AWARD_PERIOD: "",  // text
-  RANKNAME_OF_NOMINEE_First_Middle_Initial_Last: "",  // text
-  MAJCOM_FLDCOM_FOA_OR_DRU: "",  // text
-  DAFSCDUTY_TITLE: "",  // text
-  NOMINEES_TELEPHONE__DSN__Commercial: "",  // text
-  UNITOFFICE_SYMBOLSTREET_ADDRESSBASESTATEZIP_CODE: "",  // text
-  RANKNAME_OF_UNIT_COMMANDER_First_Middle_Initial_LastCOMMANDERS_TELEPHONE_DSN__Commercial: "",  // text
-  SPECIFIC_ACCOMPLISHMENTS_Use_Performance_Statements_IAW_DAFMAN_362806: "",  // text
-  RANKNAME_OF_NOMINEE_First_Middle_Initial_Last_2: "",  // text
-  SPECIFIC_ACCOMPLISHMENTS_Use_Performance_Statements_IAW_DAFMAN_362806_Continued: "",  // text
+  award: "",  // text
+  category: "",  // text
+  award_period: "",  // text
+  rankname_of_nominee: "",  // text
+  majcom_fldcom_foa_or_dru: "",  // text
+  dafscduty_title: "",  // text
+  nominees_telephone: "",  // text
+  unitoffice_symbol: "",  // text
+  unit_commander: "",  // text
+  accomplishments: "",  // text
+  rankname_of_nominee_2: "",  // text
+  accomplishments_continued: "",  // text
 ) = render-form(
   schema: json("FIELDS.json"),
   backgrounds: ("page1.png", "page2.png",),
   values: (
-    "AWARD": AWARD,
-    "CATEGORY If Applicable": CATEGORY_If_Applicable,
-    "AWARD PERIOD": AWARD_PERIOD,
-    "RANKNAME OF NOMINEE First Middle Initial Last": RANKNAME_OF_NOMINEE_First_Middle_Initial_Last,
-    "MAJCOM FLDCOM FOA OR DRU": MAJCOM_FLDCOM_FOA_OR_DRU,
-    "DAFSCDUTY TITLE": DAFSCDUTY_TITLE,
-    "NOMINEES TELEPHONE  DSN  Commercial": NOMINEES_TELEPHONE__DSN__Commercial,
-    "UNITOFFICE SYMBOLSTREET ADDRESSBASESTATEZIP CODE": UNITOFFICE_SYMBOLSTREET_ADDRESSBASESTATEZIP_CODE,
-    "RANKNAME OF UNIT COMMANDER First Middle Initial LastCOMMANDERS TELEPHONE DSN  Commercial": RANKNAME_OF_UNIT_COMMANDER_First_Middle_Initial_LastCOMMANDERS_TELEPHONE_DSN__Commercial,
-    "SPECIFIC ACCOMPLISHMENTS Use Performance Statements IAW DAFMAN 362806": SPECIFIC_ACCOMPLISHMENTS_Use_Performance_Statements_IAW_DAFMAN_362806,
-    "RANKNAME OF NOMINEE First Middle Initial Last_2": RANKNAME_OF_NOMINEE_First_Middle_Initial_Last_2,
-    "SPECIFIC ACCOMPLISHMENTS Use Performance Statements IAW DAFMAN 362806 Continued": SPECIFIC_ACCOMPLISHMENTS_Use_Performance_Statements_IAW_DAFMAN_362806_Continued,
+    "award": award,
+    "category": category,
+    "award_period": award_period,
+    "rankname_of_nominee": rankname_of_nominee,
+    "majcom_fldcom_foa_or_dru": majcom_fldcom_foa_or_dru,
+    "dafscduty_title": dafscduty_title,
+    "nominees_telephone": nominees_telephone,
+    "unitoffice_symbol": unitoffice_symbol,
+    "unit_commander": unit_commander,
+    "accomplishments": accomplishments,
+    "rankname_of_nominee_2": rankname_of_nominee_2,
+    "accomplishments_continued": accomplishments_continued,
   ),
   debug: debug,
 )

--- a/quills/daf1206/0.1.0/plate.typ
+++ b/quills/daf1206/0.1.0/plate.typ
@@ -7,22 +7,22 @@
 #let vals = (:)
 
 // --- Admin fields (page 1 header) ---
-#if "AWARD" in data { vals.insert("AWARD", data.AWARD) }
-#if "CATEGORY" in data { vals.insert("CATEGORY_If_Applicable", data.CATEGORY) }
-#if "AWARD_PERIOD" in data { vals.insert("AWARD_PERIOD", data.AWARD_PERIOD) }
+#if "award" in data { vals.insert("award", data.award) }
+#if "category" in data { vals.insert("category", data.category) }
+#if "award_period" in data { vals.insert("award_period", data.award_period) }
 
-#if "RANKNAME_OF_NOMINEE" in data { vals.insert("RANKNAME_OF_NOMINEE_First_Middle_Initial_Last", data.RANKNAME_OF_NOMINEE) }
-#if "RANKNAME_OF_NOMINEE" in data { vals.insert("RANKNAME_OF_NOMINEE_First_Middle_Initial_Last_2", data.RANKNAME_OF_NOMINEE) }
+#if "rankname_of_nominee" in data { vals.insert("rankname_of_nominee", data.rankname_of_nominee) }
+#if "rankname_of_nominee" in data { vals.insert("rankname_of_nominee_2", data.rankname_of_nominee) }
 
-#if "MAJCOM_FLDCOM_FOA_OR_DRU" in data { vals.insert("MAJCOM_FLDCOM_FOA_OR_DRU", data.MAJCOM_FLDCOM_FOA_OR_DRU) }
-#if "DAFSCDUTY_TITLE" in data { vals.insert("DAFSCDUTY_TITLE", data.DAFSCDUTY_TITLE) }
-#if "NOMINEES_TELEPHONE" in data { vals.insert("NOMINEES_TELEPHONE__DSN__Commercial", data.NOMINEES_TELEPHONE) }
-#if "UNITOFFICE_SYMBOL" in data { vals.insert("UNITOFFICE_SYMBOLSTREET_ADDRESSBASESTATEZIP_CODE", data.UNITOFFICE_SYMBOL) }
-#if "UNIT_COMMANDER" in data { vals.insert("RANKNAME_OF_UNIT_COMMANDER_First_Middle_Initial_LastCOMMANDERS_TELEPHONE_DSN__Commercial", data.UNIT_COMMANDER) }
+#if "majcom_fldcom_foa_or_dru" in data { vals.insert("majcom_fldcom_foa_or_dru", data.majcom_fldcom_foa_or_dru) }
+#if "dafscduty_title" in data { vals.insert("dafscduty_title", data.dafscduty_title) }
+#if "nominees_telephone" in data { vals.insert("nominees_telephone", data.nominees_telephone) }
+#if "unitoffice_symbol" in data { vals.insert("unitoffice_symbol", data.unitoffice_symbol) }
+#if "unit_commander" in data { vals.insert("unit_commander", data.unit_commander) }
 
 // --- Accomplishments (page 1 & 2 content) ---
-#if "ACCOMPLISHMENTS" in data { vals.insert("SPECIFIC_ACCOMPLISHMENTS_Use_Performance_Statements_IAW_DAFMAN_362806", data.ACCOMPLISHMENTS) }
-#if "ACCOMPLISHMENTS_CONTINUED" in data { vals.insert("SPECIFIC_ACCOMPLISHMENTS_Use_Performance_Statements_IAW_DAFMAN_362806_Continued", data.ACCOMPLISHMENTS_CONTINUED) }
+#if "accomplishments" in data { vals.insert("accomplishments", data.accomplishments) }
+#if "accomplishments_continued" in data { vals.insert("accomplishments_continued", data.accomplishments_continued) }
 
 // Render the form with assembled values
 #form(..vals)

--- a/templates/daf1206.md
+++ b/templates/daf1206.md
@@ -2,30 +2,30 @@
 QUILL: daf1206@0.1.0
 
 # EDIT: Award name (e.g., "AIR AND SPACE ACHIEVEMENT MEDAL")
-AWARD: "AWARD NAME"
+award: "AWARD NAME"
 # EDIT: Category (If Applicable)
-CATEGORY: ""
+category: ""
 # EDIT: Award Period (e.g., "1 Jan 24 - 31 Dec 24")
-AWARD_PERIOD: "1 Jan 2X - 31 Dec 2X"
+award_period: "1 Jan 2X - 31 Dec 2X"
 # EDIT: Rank/Name of Nominee (First, Middle Initial, Last)
-RANKNAME_OF_NOMINEE: "LAST, FIRST M."
+rankname_of_nominee: "LAST, FIRST M."
 # EDIT: MAJCOM/FLDCOM/FOA/DRU
-MAJCOM_FLDCOM_FOA_OR_DRU: ""
+majcom_fldcom_foa_or_dru: ""
 # EDIT: DAFSC/Duty Title
-DAFSCDUTY_TITLE: ""
+dafscduty_title: ""
 # EDIT: Nominee's Telephone (DSN/Commercial)
-NOMINEES_TELEPHONE: ""
+nominees_telephone: ""
 # EDIT: Unit/Office Symbol/Street Address/Base/State/Zip Code
-UNITOFFICE_SYMBOL: ""
+unitoffice_symbol: ""
 # EDIT: Rank/Name of Unit Commander & Telephone
-UNIT_COMMANDER: ""
+unit_commander: ""
 
 # EDIT: Specific Accomplishments (Page 1)
-ACCOMPLISHMENTS: |-
+accomplishments: |-
   - 
   - 
 
 # EDIT: Specific Accomplishments (Continued - Page 2)
-ACCOMPLISHMENTS_CONTINUED: |-
+accomplishments_continued: |-
   - 
 ---


### PR DESCRIPTION
## Summary
Refactored all field names in the DAF1206 form from UPPER_CASE to snake_case for improved consistency and readability across the codebase.

## Key Changes
- **form.typ**: Updated all function parameters and their corresponding field mappings from UPPER_CASE to snake_case (e.g., `AWARD` → `award`, `RANKNAME_OF_NOMINEE_First_Middle_Initial_Last` → `rankname_of_nominee`)
- **FIELDS.json**: Simplified and standardized all field names in the schema to use snake_case with descriptive but concise naming (e.g., `CATEGORY If Applicable` → `category`, `SPECIFIC ACCOMPLISHMENTS Use Performance Statements IAW DAFMAN 362806` → `accomplishments`)
- **plate.typ**: Updated all field references and conditional checks to use the new snake_case naming convention
- **Quill.yaml**: Converted all field definitions in the configuration to snake_case
- **example.md & templates/daf1206.md**: Updated example and template files to reflect the new field naming

## Implementation Details
- Field names are now consistently lowercase with underscores separating words, following Python/Rust naming conventions
- Complex field descriptions were simplified (e.g., `RANKNAME_OF_UNIT_COMMANDER_First_Middle_Initial_LastCOMMANDERS_TELEPHONE_DSN__Commercial` → `unit_commander`)
- All references across form rendering, configuration, and documentation were updated to maintain consistency
- No functional changes to form behavior or data handling

https://claude.ai/code/session_01RJGorMNxC1qBM59UpSiCw1