### PR TITLE
Replace template placeholders with concrete example content

### DIFF
--- a/templates/cmu_letter_template.md
+++ b/templates/cmu_letter_template.md
@@ -21,7 +21,7 @@ In the data above, edit:
 - Signature block
 -->
 
-Dear {:Dr. Heinz Doofenshmirtz:},
+Dear Dr. Heinz Doofenshmirtz,
 
 Write your letter content here. This template uses the CMU letter format for professional academic correspondence.
 

--- a/templates/loc.md
+++ b/templates/loc.md
@@ -21,14 +21,12 @@ compress_indorsements: true
 # Based on LOCAR template from https://www.shaw.af.mil/Portals/98/Docs/Legal/Revamp/2022%20LOCAR%20TEMPLATE%20(Enlisted).docx
 ---
 
-**NOTE: This template is undergoing major refinement. It is included for demonstration purposes.**
-
 <!-- EDIT: Describe the incident: what the member did or failed to do, citing specific incidents and dates, and if possible, with UCMJ articles. -->
-Investigation has disclosed the {:incident_description:}.
+Investigation has disclosed that on 8 March 2026, you failed to report to 0730 formation as directed and did not notify your supervisor until 0815.
 
 <!-- EDIT: Counseling paragraph: Discuss the impact of the member's actions and what improvement is expected. -->
 You are hereby counseled.
-{:impact_and_expected_improvement:}.
+Your actions disrupted accountability procedures and delayed mission tasking for your section. You are expected to report on time for all formations and immediately notify your chain of command if an emergency prevents timely reporting.
 Your conduct is unacceptable and any future misconduct may result in more severe action.
 
 The following information required by the Privacy Act is provided for your information. **AUTHORITY**: 10 U.S.C. § 8013. **PURPOSE**: To obtain any comments or documents you desire to submit (on a voluntary basis) for consideration concerning this action. **ROUTINE USES**: Provides you an opportunity to submit comments or documents for consideration. If provided, the comments and documents you submit become a part of the action. **DISCLOSURE**: Your written acknowledgement of receipt and signature are mandatory. Any other comments or documents you provide are voluntary.
@@ -43,7 +41,7 @@ signature_block: SUBJECT FIRST M. LAST, RANK, USAF
 ---
 
 <!-- EDIT: First Indorsement: Subject acknowledges receipt of the LOC -->
-I acknowledge receipt and understanding of this letter on {:date and time:}. I understand that I have 3 duty days from the date I received this letter to provide a response and that I must include in my response any comments or documents I wish to be considered concerning this Letter of Counseling.
+I acknowledge receipt and understanding of this letter on 10 March 2026 at 1430. I understand that I have 3 duty days from the date I received this letter to provide a response and that I must include in my response any comments or documents I wish to be considered concerning this Letter of Counseling.
 
 ---
 CARD: indorsement
@@ -76,4 +74,4 @@ date: "Date: _____________"
 ---
 
 <!-- EDIT: Fourth Indorsement: Subject acknowledges final decision -->
-I acknowledge receipt of the final decision regarding disposition of this Letter of Counseling on {:date and time:}.
+I acknowledge receipt of the final decision regarding disposition of this Letter of Counseling on 14 March 2026 at 0930.

--- a/templates/pass_request.md
+++ b/templates/pass_request.md
@@ -6,12 +6,12 @@ letterhead_caption:
   - UNIVERSITY OF PITTSBURGH, PA
 memo_for:
   - AFROTC DET 730/CC
-memo_from: !fill
+memo_from:
   - 2d Lt First M. Last
-subject: !fill DD Month YYYY – DD Month YYYY, Special Pass Request
+subject: 15 May 2026 – 18 May 2026, Special Pass Request
 references:
   - DAFI 36-3003, 07 August 2024, Military Leave Program
-signature_block: !fill
+signature_block:
   - FIRST M. LAST, 2d Lt, USAF
   - AFIT Masters Student
 font_size: 11
@@ -22,18 +22,18 @@ In the data above, edit;
   - Signature Block
   - Subject
 ---------------->
-**PURPOSE:** The purpose of the memorandum is to request a 4-day pass, in accordance with DAFI 36-3003, for traveling to {:Area 51 for personal research:}.
+**PURPOSE:** The purpose of the memorandum is to request a 4-day pass, in accordance with DAFI 36-3003, for traveling to Columbus, Ohio to visit family.
 
 <!-------------
 In Narrative section below, edit:
 - Flight and transit details
 - Document completion of AF4392 if age 25 or under
 --------------->
-**NARRATIVE:** On {:DD Month YYYY:}, depart via {:UA2424 at 0240 ET:}. On {:DD Month YYYY:}, return via {:UA1234 at 1300 ET:}. Transit to and from {:PIT with POV:}. I do not need to complete AF4392 to comply with travel risk requirements because I am not under the age of 26.
+**NARRATIVE:** On 15 May 2026, depart via UA2424 at 0240 ET. On 18 May 2026, return via UA1234 at 1300 ET. Transit to and from PIT with POV. I do not need to complete AF4392 to comply with travel risk requirements because I am not under the age of 26.
 
 **REFERENCED REGULATION:** “5.3. Special Pass. Unit commanders may award 3 or 4-day special passes for special occasions or circumstances, such as reenlistment or for some type of special recognition or compensatory time off. They may delegate approval to a level no lower than squadron section commander, deputies, or equivalents. (T-1) Special passes start after normal working hours on a given day. They stop at the beginning of normal working hours on either the 4th day for a 3 -day special pass or the 5th day for a 4-day special pass. A 3-day special pass can be Friday through Sunday, Saturday through Monday, or Tuesday through Thursday. A 4-day special pass can be Thursday through Sunday or Saturday through Tuesday or Friday through Monday. This applies to a normal Monday through Friday workweek. See paragraph 2.1.2 for safe travel guidelines.”
 
-If you have any questions, please contact me at {:airman.snuffy@us.af.mil:} or {:(123) 456-7890:}.
+If you have any questions, please contact me at first.last@us.af.mil or (123) 456-7890.
 
 ---
 CARD: indorsement

--- a/templates/rebuttal.md
+++ b/templates/rebuttal.md
@@ -1,15 +1,15 @@
 ---
 QUILL: usaf_memo@0.2
 letterhead_title: DEPARTMENT OF THE AIR FORCE
-letterhead_caption: !fill
+letterhead_caption:
   - YOUR SQUADRON HERE
   - USAF BASE, STATE
-memo_for: !fill
+memo_for:
   - Issuer's Rank FIRST M. LAST, USAF
-memo_from: !fill
+memo_from:
   - Subject's ORG/SYMBOL
-subject: !fill Response to Letter of Counseling, (Subject of LOC), dated DD Month YYYY
-signature_block: !fill
+subject: Response to Letter of Counseling, Late Arrival to Formation, dated 10 March 2026
+signature_block:
   - Subject's FIRST M. LAST, Rank, USAF
   - Duty Title
 ---
@@ -19,7 +19,7 @@ signature_block: !fill
   - State the date and subject matter clearly
   - Express intent to respond professionally
 ------------------------------------------------------>
-I received the Letter of Counseling dated {:DD Month YYYY:} regarding {:my late arrival to formation on DD Month YYYY:}. I respectfully submit this response for your consideration.
+I received the Letter of Counseling dated 10 March 2026 regarding my late arrival to formation on 8 March 2026. I respectfully submit this response for your consideration.
 
 <!-----------------------------------------------------
 2. RESPONSE TO ALLEGATIONS


### PR DESCRIPTION
### Motivation

- Remove fragile `!fill` front-matter fields and `{:placeholder:}` inline markers so templates do not surface immature spec tokens to end users.
- Provide minimal, realistic example context so templates render with usable, sensible defaults out of the box.

### Description

- Replaced `!fill` front-matter entries with concrete minimal values in `templates/pass_request.md` and `templates/rebuttal.md` and added realistic signature/subject fields. 
- Replaced inline `{:...:}` placeholder markers with realistic example content across `templates/pass_request.md`, `templates/rebuttal.md`, `templates/loc.md`, and `templates/cmu_letter_template.md` (dates, contact info, narrative text). 
- Removed the LOC "undergoing major refinement" warning so immature-spec messaging is not present in `templates/loc.md`.
- Ensured files end consistently and adjusted minor formatting to keep templates coherent and ready for use.

### Testing

- Ran `rg -n "!fill|\{:[^}]*:\}" templates` and confirmed there are no remaining placeholder tokens (no matches).
- Verified the four updated templates are present and contain the new example content: `templates/pass_request.md`, `templates/rebuttal.md`, `templates/loc.md`, and `templates/cmu_letter_template.md`.
- Local repository inspection showed the intended changes to those template files were applied successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d643740e44832397d5b3b0f019ff7a)