### PR TITLE
Migrate to @quillmark/wasm 0.53.x and correct Quill date field types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,7 +22,6 @@ release-artifacts/
 outputs/
 
 MIGRATION.md
-references/
 
 # Claude metadata
 .claude/

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.14.0",
       "devDependencies": {
         "@quillmark/registry": "^0.12.0",
-        "@quillmark/wasm": "^0.53.0"
+        "@quillmark/wasm": "^0.53.1"
       }
     },
     "node_modules/@quillmark/registry": {
@@ -31,9 +31,9 @@
       }
     },
     "node_modules/@quillmark/wasm": {
-      "version": "0.53.0",
-      "resolved": "https://registry.npmjs.org/@quillmark/wasm/-/wasm-0.53.0.tgz",
-      "integrity": "sha512-Ap+SV26wwDQOaDDju48tZ6rPNvMwYFhd1euf29+rE0MZtJnoWuFldhlv+C6/xiYSrJa6/rOfZ/Th6KvjPJGnww==",
+      "version": "0.53.1",
+      "resolved": "https://registry.npmjs.org/@quillmark/wasm/-/wasm-0.53.1.tgz",
+      "integrity": "sha512-analk34lLsxN6RQRVRgp9K8+aqHCUhSJPxZP04xNrVM9/ADpT3/hGM5KPlVM33fpkqKo9AQfWAOnl4PgjXadew==",
       "dev": true,
       "license": "MIT OR Apache-2.0",
       "peer": true

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.14.0",
       "devDependencies": {
         "@quillmark/registry": "^0.12.0",
-        "@quillmark/wasm": "^0.51.0"
+        "@quillmark/wasm": "^0.53.0"
       }
     },
     "node_modules/@quillmark/registry": {
@@ -31,9 +31,9 @@
       }
     },
     "node_modules/@quillmark/wasm": {
-      "version": "0.51.0",
-      "resolved": "https://registry.npmjs.org/@quillmark/wasm/-/wasm-0.51.0.tgz",
-      "integrity": "sha512-DRsW4mrMXZIO/YnvJBVqbfA4o3q+FDK8pKaKY3/IEDGwLl7siqX1rIiKVaK7q8t6aOZDE14n7YN0GiuK9mEP0g==",
+      "version": "0.53.0",
+      "resolved": "https://registry.npmjs.org/@quillmark/wasm/-/wasm-0.53.0.tgz",
+      "integrity": "sha512-Ap+SV26wwDQOaDDju48tZ6rPNvMwYFhd1euf29+rE0MZtJnoWuFldhlv+C6/xiYSrJa6/rOfZ/Th6KvjPJGnww==",
       "dev": true,
       "license": "MIT OR Apache-2.0",
       "peer": true

--- a/package.json
+++ b/package.json
@@ -37,6 +37,6 @@
   "dependencies": {},
   "devDependencies": {
     "@quillmark/registry": "^0.12.0",
-    "@quillmark/wasm": "^0.51.0"
+    "@quillmark/wasm": "^0.53.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -37,6 +37,6 @@
   "dependencies": {},
   "devDependencies": {
     "@quillmark/registry": "^0.12.0",
-    "@quillmark/wasm": "^0.53.0"
+    "@quillmark/wasm": "^0.53.1"
   }
 }

--- a/prose/references/typst-auto-date-migration.md
+++ b/prose/references/typst-auto-date-migration.md
@@ -1,0 +1,43 @@
+# Migration: Typst date auto-conversion & `parse-date` removal
+
+**Audience:** Maintainers updating existing Quill Typst plates after the date helper rework.
+
+## What changed
+
+- **JSON Schema** fields with `type: string` and `format: "date"` are converted to Typst `datetime` inside the generated `data` dictionary (top-level and per card type).
+- **`parse-date` is no longer part of the public helper API.** Only `data` should be imported for normal plates.
+- **`format: "date-time"`** is unchanged: it is **not** auto-converted; keep any manual handling you already use.
+
+## Plate edits (checklist)
+
+1. **Imports:** use only `data`.
+
+   ```typst
+   // Before
+   #import "@local/quillmark-helper:0.1.0": data, parse-date
+
+   // After
+   #import "@local/quillmark-helper:0.1.0": data
+   ```
+
+2. **Top-level dates:** drop `parse-date(...)`; use the field from `data`.
+
+   ```typst
+   // Before
+   #parse-date(data.effective_date)
+
+   // After
+   #data.effective_date
+   ```
+
+3. **Card dates:** same idea—read the key on each card object after `data` is built (e.g. `card.date`); do not call a helper parser.
+
+4. **Optional / bad values:** if a date string is missing or not parseable as an ISO date, the helper leaves a **`none`** (or skips conversion where appropriate). Keep `#if field != none { ... }` or `.at(..., default: ...)` patterns as needed.
+
+## Schema reminder
+
+Auto-conversion applies only when the field is declared in the Quill JSON Schema as a **`date`** (`format: "date"` on a string). If a field should stay a raw string, do not mark it as `format: "date"`.
+
+## Internal detail (usually ignore)
+
+The Typst backend injects `date_fields` and `card_date_fields` into `__meta__`; the helper consumes `__meta__` and never exposes it to plates. No plate changes are required for that metadata beyond fixing imports and removing `parse-date` call sites.

--- a/quills/af4141/0.1.0/Quill.yaml
+++ b/quills/af4141/0.1.0/Quill.yaml
@@ -41,7 +41,7 @@ cards:
     fields:
       date:
         title: Date
-        type: string
+        type: date
         ui:
           group: Record
         description: Date of the action (column A).
@@ -63,7 +63,7 @@ cards:
 
       written_grade_date:
         title: Written Grade Date
-        type: string
+        type: date
         ui:
           group: Record
           compact: true
@@ -79,7 +79,7 @@ cards:
 
       positional_grade_date:
         title: Positional Grade Date
-        type: string
+        type: date
         ui:
           group: Record
           compact: true

--- a/quills/af4141/0.1.0/example.md
+++ b/quills/af4141/0.1.0/example.md
@@ -30,7 +30,7 @@ commanders_auth: ""
 <!-- Example 1: Initial assignment to a unit -->
 ---
 CARD: experience
-date: "15 Jan 25"
+date: 2025-01-15
 action: "Assigned to 1 ACCS/DOT as Weapons Director"
 written_grade: ""
 written_grade_date: ""
@@ -42,10 +42,10 @@ auth_or_remarks: "Initial assignment"
 <!-- Example 2: Written upgrade evaluation -->
 ---
 CARD: experience
-date: "15 Mar 25"
+date: 2025-03-15
 action: "Completed written upgrade evaluation for 3-Level"
 written_grade: "3"
-written_grade_date: "15 Mar 25"
+written_grade_date: 2025-03-15
 positional_grade: ""
 positional_grade_date: ""
 auth_or_remarks: "Per AFMAN 13-1CRCV1"
@@ -54,31 +54,31 @@ auth_or_remarks: "Per AFMAN 13-1CRCV1"
 <!-- Example 3: Positional (live-environment) upgrade / certification -->
 ---
 CARD: experience
-date: "20 Jun 25"
+date: 2025-06-20
 action: "Certified Mission Ready — positional upgrade"
 written_grade: ""
 written_grade_date: ""
 positional_grade: "4"
-positional_grade_date: "20 Jun 25"
+positional_grade_date: 2025-06-20
 auth_or_remarks: "SSgt Jones, T.R."
 ---
 
 <!-- Example 4: Combined written + positional upgrade (both columns filled) -->
 ---
 CARD: experience
-date: "1 Aug 25"
+date: 2025-08-01
 action: "Upgrade evaluation — written and positional"
 written_grade: "4"
-written_grade_date: "1 Aug 25"
+written_grade_date: 2025-08-01
 positional_grade: "4"
-positional_grade_date: "1 Aug 25"
+positional_grade_date: 2025-08-01
 auth_or_remarks: "Verified by unit commander"
 ---
 
 <!-- Example 5: PCS departure — no grade columns needed -->
 ---
 CARD: experience
-date: "1 Sep 25"
+date: 2025-09-01
 action: "PCS to 726 ACS/MOC, Tinker AFB OK"
 written_grade: ""
 written_grade_date: ""

--- a/quills/af4141/0.1.0/plate.typ
+++ b/quills/af4141/0.1.0/plate.typ
@@ -3,6 +3,16 @@
 
 #set text(font: ("NimbusRomNo9L", "Times New Roman", "serif"))
 
+// `type: date` fields arrive as Typst `datetime`; PDF overlay expects strings.
+#let form-cell(v) = {
+  if v == none { "" }
+  else if type(v) == datetime {
+    v.display("[month padding:none]/[day padding:none]/[year]")
+  } else {
+    str(v)
+  }
+}
+
 // Column order within each 7-field row group
 #let col-keys = (
   "date",
@@ -33,7 +43,7 @@
     if card.CARD == "experience" {
       if row < max-rows {
         for (col, key) in col-keys.enumerate() {
-          let value = card.at(key, default: "")
+          let value = form-cell(card.at(key, default: none))
           if value != "" {
             let field-name = if row < 16 {
               // Page 1: fields start at index 4, stride 7

--- a/quills/classic_resume/0.1.0/Quill.yaml
+++ b/quills/classic_resume/0.1.0/Quill.yaml
@@ -38,17 +38,17 @@ cards:
         title: Section Title
         type: string
         default: Experience
-      headingLeft:
+      heading_left:
         title: Heading Left (e.g., Company/School)
         type: string
         required: true
-      headingRight:
+      heading_right:
         title: Heading Right (e.g., Location)
         type: string
-      subheadingLeft:
+      subheading_left:
         title: Subheading Left (e.g., Title/Degree)
         type: string
-      subheadingRight:
+      subheading_right:
         title: Subheading Right (e.g., Date)
         type: string
 

--- a/quills/classic_resume/0.1.0/example.md
+++ b/quills/classic_resume/0.1.0/example.md
@@ -36,10 +36,10 @@ cells:
 ---
 CARD: experience_section
 title: Work Experience
-headingLeft: Templar Archives Research Division
-headingRight: August 2024 – Present
-subheadingLeft: Psionic Research Analyst
-subheadingRight: Aiur
+heading_left: Templar Archives Research Division
+heading_right: August 2024 – Present
+subheading_left: Psionic Research Analyst
+subheading_right: Aiur
 ---
 
 - Analyzed Khala disruption patterns following Amon's corruption, developing countermeasures to protect remaining neural link infrastructure.
@@ -47,10 +47,10 @@ subheadingRight: Aiur
 
 ---
 CARD: experience_section
-headingLeft: Terran Dominion Ghost Academy
-headingRight: May 2025 – July 2025
-subheadingLeft: Covert Ops Trainee
-subheadingRight: Tarsonis (Remote)
+heading_left: Terran Dominion Ghost Academy
+heading_right: May 2025 – July 2025
+subheading_left: Covert Ops Trainee
+subheading_right: Tarsonis (Remote)
 ---
 
 - Developed tactical HUD displays for Ghost operatives integrating real-time Zerg hive cluster intelligence.
@@ -59,10 +59,10 @@ subheadingRight: Tarsonis (Remote)
 
 ---
 CARD: experience_section
-headingLeft: Abathur's Evolution Pit
-headingRight: June 2023 – July 2023
-subheadingLeft: Biomass Research Intern
-subheadingRight: Char
+heading_left: Abathur's Evolution Pit
+heading_right: June 2023 – July 2023
+subheading_left: Biomass Research Intern
+subheading_right: Char
 ---
 
 - Developed tracking algorithms for Overlord surveillance networks; supported pattern-of-life analysis for Terran outpost elimination.
@@ -70,10 +70,10 @@ subheadingRight: Char
 
 ---
 CARD: experience_section
-headingLeft: Raynor's Raiders
-headingRight: January 2018 – June 2020
-subheadingLeft: Combat Engineer
-subheadingRight: Mar Sara
+heading_left: Raynor's Raiders
+heading_right: January 2018 – June 2020
+subheading_left: Combat Engineer
+subheading_right: Mar Sara
 ---
 
 - Administered Hyperion shipboard systems, SCV maintenance protocols, and bunker defense automation for 30,000+ colonists.
@@ -84,18 +84,18 @@ subheadingRight: Mar Sara
 ---
 CARD: experience_section
 title: Education
-headingLeft: Carnegie Mellon University
-headingRight: December 2025
-subheadingLeft: Master of Information Technology Strategy
-subheadingRight: Pittsburgh, PA
+heading_left: Carnegie Mellon University
+heading_right: December 2025
+subheading_left: Master of Information Technology Strategy
+subheading_right: Pittsburgh, PA
 ---
 
 ---
 CARD: experience_section
-headingLeft: United States Air Force Academy
-headingRight: May 2024
-subheadingLeft: BS, Data Science
-subheadingRight: Colorado Springs, CO
+heading_left: United States Air Force Academy
+heading_right: May 2024
+subheading_left: BS, Data Science
+subheading_right: Colorado Springs, CO
 ---
 
 - Distinguished Graduate (top 10%); Chinese language minor (L2+/R1 on DLPT).
@@ -104,24 +104,24 @@ subheadingRight: Colorado Springs, CO
 
 ---
 CARD: experience_section
-headingLeft: Western Governors University
-headingRight: April 2022
-subheadingLeft: BS, Cybersecurity and Information Assurance
-subheadingRight: Remote
+heading_left: Western Governors University
+heading_right: April 2022
+subheading_left: BS, Cybersecurity and Information Assurance
+subheading_right: Remote
 ---
 
 ---
 CARD: experience_section
-headingLeft: Community College of the Air Force
-headingRight: February 2019
-subheadingLeft: AS, Information Systems Technology
-subheadingRight: Remote
+heading_left: Community College of the Air Force
+heading_right: February 2019
+subheading_left: AS, Information Systems Technology
+subheading_right: Remote
 ---
 
 ---
 CARD: experience_section
 title: Cyber Competition
-headingLeft: 1st in SANS Academy Cup 2024
+heading_left: 1st in SANS Academy Cup 2024
 ---
 
 - Competed as the Delogrand Web Exploit SME, solving SQLi, API, and HTTP packet crafting problems.
@@ -129,7 +129,7 @@ headingLeft: 1st in SANS Academy Cup 2024
 
 ---
 CARD: experience_section
-headingLeft: 1st in NCX 2023
+heading_left: 1st in NCX 2023
 ---
 
 - Developed strategies, defensive scripts, and exploits for the Cyber Combat event.
@@ -137,7 +137,7 @@ headingLeft: 1st in NCX 2023
 
 ---
 CARD: experience_section
-headingLeft: 1st in SANS Academy Cup 2023
+heading_left: 1st in SANS Academy Cup 2023
 ---
 
 - Competed as the Delogrand Web Exploit SME, solving XSS, XXE, SQLi, and HTTP crafting problems.
@@ -145,14 +145,14 @@ headingLeft: 1st in SANS Academy Cup 2023
 
 ---
 CARD: experience_section
-headingLeft: 1st in RMCS 2023
+heading_left: 1st in RMCS 2023
 ---
 
 - Competed as the Delogrand Web Exploit SME, solving obfuscated JS, Wasm, XSS, and SQLi problems.
 
 ---
 CARD: experience_section
-headingLeft: 1st in NCX 2022
+heading_left: 1st in NCX 2022
 ---
 
 - Trained and strategized teams for the Cyber Combat event.

--- a/quills/classic_resume/0.1.0/plate.typ
+++ b/quills/classic_resume/0.1.0/plate.typ
@@ -1,4 +1,4 @@
-#import "@local/quillmark-helper:0.1.0": data, parse-date
+#import "@local/quillmark-helper:0.1.0": data
 #import "@local/ttq-classic-resume:0.1.0": *
 
 #show: resume
@@ -15,10 +15,10 @@
 
   if card.CARD == "experience_section" {
     timeline-entry(
-      heading-left: card.at("headingLeft", default: ""),
-      heading-right: card.at("headingRight", default: ""),
-      subheading-left: card.at("subheadingLeft", default: none),
-      subheading-right: card.at("subheadingRight", default: none),
+      heading-left: card.at("heading_left", default: ""),
+      heading-right: card.at("heading_right", default: ""),
+      subheading-left: card.at("subheading_left", default: none),
+      subheading-right: card.at("subheading_right", default: none),
       body: card.at("BODY", default: none),
     )
   } else if card.CARD == "skills_section" {

--- a/quills/cmu_letter/0.1.0/plate.typ
+++ b/quills/cmu_letter/0.1.0/plate.typ
@@ -1,4 +1,4 @@
-#import "@local/quillmark-helper:0.1.0": data, parse-date
+#import "@local/quillmark-helper:0.1.0": data
 #import "@local/tonguetoquill-cmu-letter:0.1.0": backmatter, frontmatter, mainmatter
 
 #show: frontmatter.with(
@@ -6,7 +6,11 @@
   department: data.department,
   address: data.address,
   url: data.url,
-  date: if "date" in data { parse-date(data.date) } else { datetime.today() },
+  date: if "date" in data and data.date != none {
+    data.date
+  } else {
+    datetime.today()
+  },
   recipient: data.recipient,
 )
 

--- a/quills/daf4392/0.1.0/plate.typ
+++ b/quills/daf4392/0.1.0/plate.typ
@@ -1,5 +1,12 @@
 #import "@local/quillmark-helper:0.1.0": data
 
+// `type: date` fields arrive as Typst `datetime`; overlay text must be plain strings.
+#let show-date(v) = {
+  if v == none { "" }
+  else if type(v) == datetime { v.display("[month padding:none]/[day padding:none]/[year]") }
+  else { str(v) }
+}
+
 #set page(width: 8.5in, height: 11in, margin: 0in)
 #set text(font: "Arimo", size: 10pt)
 
@@ -19,7 +26,7 @@
 #check(411pt, 67pt, mode == "other")
 
 // Fields
-#tf(40pt, 100pt)[#data.at("departure_date", default: "")]
+#tf(40pt, 100pt)[#show-date(data.at("departure_date", default: none))]
 #tf(123pt, 100pt)[#data.at("final_destination", default: "")]
 
 // Itinerary Rows (via CARDS)
@@ -31,7 +38,7 @@
     for card in data.CARDS {
       if card.CARD == "itinerary" and row < 10 {
         let dy = dy-start + (row * dy-step)
-        tf(80pt, dy)[#card.at("date", default: "")]
+        tf(80pt, dy)[#show-date(card.at("date", default: none))]
         tf(135pt, dy)[#card.at("departure_point", default: "")]
         tf(295pt, dy)[#card.at("arrival_point", default: "")]
         tf(450pt, dy)[#card.at("rest_length", default: "")]
@@ -56,7 +63,7 @@
 
 // Acknowledgements
 #tf(40pt, 620pt)[#data.at("organization", default: "")]
-#tf(500pt, 620pt)[#data.at("briefed_date", default: "")]
+#tf(500pt, 620pt)[#show-date(data.at("briefed_date", default: none))]
 
 #tf(40pt, 650pt)[#data.at("briefee_name", default: "")]
 #tf(270pt, 650pt)[#data.at("briefee_grade", default: "")]

--- a/quills/usaf_memo/0.1.0/Quill.yaml
+++ b/quills/usaf_memo/0.1.0/Quill.yaml
@@ -80,8 +80,7 @@ main:
 
     date:
       title: Date of memo (YYYY-MM-DD); defaults to today
-      type: string
-      default: ""
+      type: date
       ui:
         group: Additional
       description: YYYY-MM-DD. Leave blank to use today's date.
@@ -204,7 +203,7 @@ cards:
         description: List of office symbols to receive copies of this endorsement.
       date:
         title: Date of endorsement (YYYY-MM-DD)
-        type: string
+        type: date
         ui:
           group: Additional
         description: Date of the endorsement. Leave blank to omit.

--- a/quills/usaf_memo/0.1.0/plate.typ
+++ b/quills/usaf_memo/0.1.0/plate.typ
@@ -1,4 +1,4 @@
-#import "@local/quillmark-helper:0.1.0": data, parse-date
+#import "@local/quillmark-helper:0.1.0": data
 #import "@local/tonguetoquill-usaf-memo:1.0.0": backmatter, frontmatter, indorsement, mainmatter
 
 // Frontmatter configuration
@@ -9,7 +9,7 @@
   letterhead_seal: image("assets/dow_seal.jpg"),
 
   // Date
-  date: parse-date(data.date),
+  date: data.at("date", default: none),
 
   // Receiver information
   memo_for: data.memo_for,

--- a/quills/usaf_memo/0.2.0/Quill.yaml
+++ b/quills/usaf_memo/0.2.0/Quill.yaml
@@ -72,7 +72,7 @@ main:
 
     tag_line:
       title: Tag line at bottom of memo
-      type: string
+      type: date
       default: ""
       ui:
         group: Letterhead
@@ -80,7 +80,7 @@ main:
 
     date:
       title: Date of memo (YYYY-MM-DD); defaults to today
-      type: string
+      type: date
       default: ""
       ui:
         group: Additional
@@ -135,6 +135,7 @@ main:
         - CONFIDENTIAL
       ui:
         group: Additional
+        compact: true
       description: Follow AFI 31-401 and applicable DoD guidance for classification markings. Leave blank for unclassified.
 
     font_size:
@@ -145,6 +146,7 @@ main:
         - 11
       ui:
         group: Additional
+        compact: true
       description: Font size for the memo text (pt).
 
 cards:
@@ -214,7 +216,7 @@ cards:
         description: List of office symbols to receive copies of this endorsement.
       date:
         title: Date of endorsement (YYYY-MM-DD)
-        type: string
+        type: date
         ui:
           group: Additional
         description: Date of the endorsement. Leave blank to omit.

--- a/quills/usaf_memo/0.2.0/Quill.yaml
+++ b/quills/usaf_memo/0.2.0/Quill.yaml
@@ -72,7 +72,7 @@ main:
 
     tag_line:
       title: Tag line at bottom of memo
-      type: date
+      type: string
       default: ""
       ui:
         group: Letterhead

--- a/quills/usaf_memo/0.2.0/Quill.yaml
+++ b/quills/usaf_memo/0.2.0/Quill.yaml
@@ -78,14 +78,6 @@ main:
         group: Letterhead
       description: Organizational motto at the bottom of the page.
 
-    date:
-      title: Date of memo (YYYY-MM-DD); defaults to today
-      type: date
-      default: ""
-      ui:
-        group: Additional
-      description: YYYY-MM-DD. Leave blank to use today's date.
-
     references:
       title: References for the memo
       type: array
@@ -137,7 +129,7 @@ main:
         group: Additional
         compact: true
       description: Follow AFI 31-401 and applicable DoD guidance for classification markings. Leave blank for unclassified.
-
+    
     font_size:
       title: Font size for the memo text (int pt)
       type: number
@@ -148,6 +140,15 @@ main:
         group: Additional
         compact: true
       description: Font size for the memo text (pt).
+
+    date:
+      title: Date of memo (YYYY-MM-DD); defaults to today
+      type: date
+      default: ""
+      ui:
+        group: Additional
+      description: YYYY-MM-DD. Leave blank to use today's date.
+
 
 cards:
   indorsement:

--- a/quills/usaf_memo/0.2.0/plate.typ
+++ b/quills/usaf_memo/0.2.0/plate.typ
@@ -1,4 +1,4 @@
-#import "@local/quillmark-helper:0.1.0": data, parse-date
+#import "@local/quillmark-helper:0.1.0": data
 #import "@local/tonguetoquill-usaf-memo:2.0.0": backmatter, frontmatter, indorsement, mainmatter
 
 // Frontmatter configuration
@@ -9,7 +9,7 @@
   letterhead_seal: image("assets/dow_seal.png"),
 
   // Date
-  date: parse-date(data.date),
+  date: data.at("date", default: none),
 
   // Receiver information
   memo_for: data.memo_for,

--- a/templates/af4141.md
+++ b/templates/af4141.md
@@ -13,7 +13,7 @@ commanders_auth: ""
 <!-- Add one CARD: experience block per row. Duplicate as needed. -->
 ---
 CARD: experience
-date: "1 Jan 25"
+date: 2025-01-01
 action: "Describe the action or event"
 written_grade: ""
 written_grade_date: ""

--- a/templates/templates.json
+++ b/templates/templates.json
@@ -28,13 +28,6 @@
 		"production": true
 	},
 	{
-		"id": "taro-template",
-		"name": "Taro Template",
-		"description": "Official Taro ice cream template",
-		"file": "taro.md",
-		"production": false
-	},
-	{
 		"id": "cmu-letter",
 		"name": "CMU Letter",
 		"description": "Carnegie Mellon University academic letter template",


### PR DESCRIPTION
## Summary

This branch upgrades the collection to **\@quillmark/wasm 0.53.x**, migrates Typst plates and `Quill.yaml` field schemas to the current standard (including dropping legacy `parse-date` usage per the date helper rework), and adds a small migration note under `prose/references/`.

It also fixes **Quill field types** that were wrong or inconsistent:

- **usaf_memo 0.2.0:** `tag_line` is organizational motto text — restored to `type: string` (it had been set to `date` by mistake).
- **af4141:** Experience row columns A, D, and F are real dates — `date`, `written_grade_date`, and `positional_grade_date` are now `type: date`. The plate formats Typst `datetime` values as strings for the PDF overlay. `example.md` and `templates/af4141.md` use **ISO 8601** (`YYYY-MM-DD`) for those fields.

## Testing

- `npm test` (validate quills + templates) passes locally.

## Commits

Six commits ahead of `main`: WASM bumps, migration helper, plate/schema migration, USAF memo `Quill.yaml` date field placement, and AF 4141 date typing + examples.