### PR TITLE
USAF memo 0.2.0: memo styles, letterhead options, and Quill schema updates

### DIFF
--- a/quills/usaf_memo/0.2.0/Quill.yaml
+++ b/quills/usaf_memo/0.2.0/Quill.yaml
@@ -87,17 +87,6 @@ main:
         group: Letterhead
       description: Organizational motto at the bottom of the page.
 
-    memo_style:
-      title: Memorandum type
-      type: string
-      enum:
-        - usaf
-        - daf
-      default: usaf
-      ui:
-        group: Letterhead
-      description: "USAF memorandum (default) or DAF headquarters memorandum. DAF changes date formatting and body paragraph layout per AFH 33-337."
-
     references:
       title: References for the memo
       type: array
@@ -138,18 +127,19 @@ main:
       ui:
         group: Additional
       description: List attachments in the order they are mentioned in the memo. Briefly describe each; do not use 'as stated' or abbreviations.
-
-    classification:
-      title: Classification level of the memo that displays in the banner
+ 
+    memo_style:
+      title: Memorandum style
       type: string
-      default: ""
-      examples:
-        - CONFIDENTIAL
+      enum:
+        - usaf
+        - daf
+      default: usaf
       ui:
         group: Additional
         compact: true
-      description: Follow AFI 31-401 and applicable DoD guidance for classification markings. Leave blank for unclassified.
-    
+      description: "USAF memorandum (default) or DAF headquarters memorandum. DAF changes date formatting and body paragraph layout per AFH 33-337."
+
     font_size:
       title: Font size for the memo text (int pt)
       type: number
@@ -167,9 +157,19 @@ main:
       default: ""
       ui:
         group: Additional
+        compact: true
       description: YYYY-MM-DD. Leave blank to use today's date.
-
-
+    classification:
+      title: Classification level of the memo that displays in the banner
+      type: string
+      default: ""
+      examples:
+        - CONFIDENTIAL
+      ui:
+        group: Additional
+        compact: true
+      description: Follow AFI 31-401 and applicable DoD guidance for classification markings. Leave blank for unclassified.
+    
 cards:
   indorsement:
     title: Routing indorsement

--- a/quills/usaf_memo/0.2.0/Quill.yaml
+++ b/quills/usaf_memo/0.2.0/Quill.yaml
@@ -78,6 +78,17 @@ main:
         group: Letterhead
       description: Organizational motto at the bottom of the page.
 
+    memo_style:
+      title: Memorandum type
+      type: string
+      enum:
+        - usaf
+        - daf
+      default: usaf
+      ui:
+        group: Letterhead
+      description: "USAF memorandum (default) or DAF headquarters memorandum. DAF changes date formatting and body paragraph layout per AFH 33-337."
+
     references:
       title: References for the memo
       type: array

--- a/quills/usaf_memo/0.2.0/Quill.yaml
+++ b/quills/usaf_memo/0.2.0/Quill.yaml
@@ -70,6 +70,15 @@ main:
         group: Letterhead
       description: The full organization name of your unit.
 
+    letterhead_seal_subtitle:
+      title: Subtitle under letterhead seal
+      type: string
+      default: ""
+      ui:
+        group: Letterhead
+        compact: true
+      description: Optional line below the DoW seal (bold caps). Leave blank to omit.
+
     tag_line:
       title: Tag line at bottom of memo
       type: string

--- a/quills/usaf_memo/0.2.0/plate.typ
+++ b/quills/usaf_memo/0.2.0/plate.typ
@@ -29,6 +29,9 @@
   // Optional classification level
   ..if "classification" in data { (classification_level: data.classification) },
 
+  // USAF vs DAF memorandum style (date format, body indentation)
+  memo_style: data.at("memo_style", default: "usaf"),
+
   // Font size
   ..if "font_size" in data { (font_size: float(data.font_size) * 1pt) },
 

--- a/quills/usaf_memo/0.2.0/plate.typ
+++ b/quills/usaf_memo/0.2.0/plate.typ
@@ -7,6 +7,7 @@
   letterhead_title: data.letterhead_title,
   letterhead_caption: data.letterhead_caption,
   letterhead_seal: image("assets/dow_seal.png"),
+  letterhead_seal_subtitle: data.at("letterhead_seal_subtitle", default: none),
 
   // Date
   date: data.at("date", default: none),

--- a/quills/usaf_memo/0.2.0/plate.typ
+++ b/quills/usaf_memo/0.2.0/plate.typ
@@ -1,5 +1,5 @@
 #import "@local/quillmark-helper:0.1.0": data
-#import "@local/tonguetoquill-usaf-memo:2.0.0": backmatter, frontmatter, indorsement, mainmatter
+#import "@local/tonguetoquill-usaf-memo:3.0.0": backmatter, frontmatter, indorsement, mainmatter
 
 // Frontmatter configuration
 #show: frontmatter.with(

--- a/scripts/update-subtrees.mjs
+++ b/scripts/update-subtrees.mjs
@@ -4,6 +4,9 @@
  * Updates all subtrees from upstream, targeting the latest version folder
  * for each quill.
  *
+ * Requires a clean git working tree (no unstaged/staged changes). Commit or
+ * stash before running; otherwise `git subtree` fails with "Cannot add".
+ *
  * Usage: node scripts/update-subtrees.mjs
  *        npm run update-subtrees
  */
@@ -17,16 +20,65 @@ import { FileSystemSource } from "@quillmark/registry";
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(__dirname, "..");
 
+/** Exits the process if there are any staged or unstaged changes. */
+function requireCleanWorkingTree(cwd) {
+  const porcelain = execFileSync("git", ["status", "--porcelain"], {
+    cwd,
+    encoding: "utf-8",
+  });
+  if (!porcelain.trim()) return;
+
+  console.error(
+    "Cannot update subtrees: working tree is not clean.\n" +
+      "Commit or stash your changes, then run again.\n\n" +
+      "git status --short:\n" +
+      porcelain
+  );
+  process.exit(1);
+}
+
 const subtrees = JSON.parse(
   readFileSync(join(repoRoot, "subtrees.json"), "utf-8")
 );
 
 const source = new FileSystemSource(join(repoRoot, "quills"));
 
+/** @param {string} a @param {string} b @returns {number} */
+function compareSemver(a, b) {
+  const pa = a.split(".").map(Number);
+  const pb = b.split(".").map(Number);
+  for (let i = 0; i < 3; i++) {
+    const d = (pa[i] ?? 0) - (pb[i] ?? 0);
+    if (d !== 0) return d;
+  }
+  return 0;
+}
+
+/**
+ * Latest X.Y.Z folder for a quill, per FileSystemSource.getManifest().
+ * @param {import("@quillmark/registry").QuillManifest} manifest
+ * @param {string} name
+ */
+function resolveLatestVersion(manifest, name) {
+  const versions = manifest.quills
+    .filter((q) => q.name === name)
+    .map((q) => q.version);
+  if (versions.length === 0) {
+    throw new Error(
+      `No versioned quill "${name}" under quills/ (need semver dir with Quill.yaml)`
+    );
+  }
+  versions.sort(compareSemver);
+  return versions[versions.length - 1];
+}
+
+const manifest = await source.getManifest();
+requireCleanWorkingTree(repoRoot);
+
 let failed = false;
 
 for (const [name, config] of Object.entries(subtrees)) {
-  const version = await source.resolveLatestVersion(name);
+  const version = resolveLatestVersion(manifest, name);
   const prefix = `quills/${name}/${version}/packages/${config.package}`;
 
   console.log("=========================================");
@@ -37,32 +89,11 @@ for (const [name, config] of Object.entries(subtrees)) {
   console.log();
 
   try {
-    let isNew = !existsSync(resolve(repoRoot, prefix));
-    let isSubtree = false;
+    const prefixAbs = resolve(repoRoot, prefix);
+    const isNew = !existsSync(prefixAbs);
 
-    if (!isNew) {
-      try {
-        const logOutput = execFileSync(
-          "git",
-          ["log", `--grep=git-subtree-dir: ${prefix}`, "-1", "--format=%H"],
-          { cwd: repoRoot, encoding: "utf-8" }
-        );
-        isSubtree = logOutput.trim().length > 0;
-      } catch (err) {
-        // ignore
-      }
-    }
-    
-    if (isNew || !isSubtree) {
-      if (!isNew) {
-        console.log(`Directory exists but is not a subtree. Converting...`);
-        // Remove the regular directory and commit the removal so subtree add works
-        execFileSync("git", ["rm", "-rf", prefix], { cwd: repoRoot, stdio: "inherit" });
-        execFileSync("git", ["commit", "-m", `chore: remove non-subtree ${prefix} prior to subtree add`, "--allow-empty"], { cwd: repoRoot, stdio: "inherit" });
-      } else {
-        console.log(`Prefix not found, adding as new subtree...`);
-      }
-      
+    if (isNew) {
+      console.log(`Prefix not found, adding as new subtree...`);
       execFileSync(
         "git",
         [
@@ -93,10 +124,9 @@ for (const [name, config] of Object.entries(subtrees)) {
         { cwd: repoRoot, stdio: "inherit" }
       );
     }
-    
+
     console.log();
-    const action = (!isNew && isSubtree) ? 'updated' : (isNew ? 'added' : 'converted and added');
-    console.log(`✓ ${name} subtree ${action} successfully`);
+    console.log(`✓ ${name} subtree ${isNew ? "added" : "updated"} successfully`);
   } catch (err) {
     console.error();
     const action = (!existsSync(resolve(repoRoot, prefix))) ? 'add' : 'update';

--- a/scripts/validate-templates.mjs
+++ b/scripts/validate-templates.mjs
@@ -142,9 +142,14 @@ try {
       // Handle error objects that might be thrown from WASM
       if (err instanceof Error) {
         entry.error = err.message;
+      } else if (err instanceof Map) {
+        entry.error = err.get('message') ?? String(err);
       } else if (typeof err === 'object' && err !== null) {
         // Try to extract message from WASM error objects
-        entry.error = err.message || JSON.stringify(err, null, 2);
+        entry.error =
+          err.message ||
+          (typeof err.get === 'function' ? err.get('message') : null) ||
+          JSON.stringify(err, null, 2);
       } else {
         entry.error = String(err);
       }

--- a/src/body.typ
+++ b/src/body.typ
@@ -13,29 +13,13 @@
 
 /// Gets the numbering format for a specific paragraph level.
 ///
-/// AFH 33-337 "The Text of the Official Memorandum" §2: "Number and letter each
-/// paragraph and subparagraph" with hierarchical numbering implied by examples.
-/// Standard military format follows the pattern: 1., a., (1), (a), etc.
-///
-/// Returns the appropriate numbering format for AFH 33-337 compliant
-/// hierarchical paragraph numbering:
-/// - Level 0: "1." (1., 2., 3., etc.)
-/// - Level 1: "a." (a., b., c., etc.)
-/// - Level 2: "(1)" ((1), (2), (3), etc.)
-/// - Level 3: "(a)" ((a), (b), (c), etc.)
-/// - Level 4+: Underlined format for deeper nesting
-///
 /// - level (int): Paragraph nesting level (0-based)
 /// -> str | function
 #let get-paragraph-numbering-format(level) = {
   paragraph-config.numbering-formats.at(level, default: "i.")
 }
 
-/// Calculates indentation width using explicit counter values.
-///
-/// Computes the exact indentation needed for hierarchical paragraph alignment
-/// by measuring the cumulative width of all ancestor paragraph numbers and their
-/// spacing. Uses the provided counter values directly (no Typst counter reads).
+/// Calculates indentation for USAF-style paragraphs from explicit counter values.
 ///
 /// - level (int): Paragraph nesting level (0-based)
 /// - level-counts (dictionary): Maps level index strings to their current counter values
@@ -49,49 +33,52 @@
     let ancestor-value = level-counts.at(str(ancestor-level), default: 1)
     let ancestor-format = get-paragraph-numbering-format(ancestor-level)
     let ancestor-number = numbering(ancestor-format, ancestor-value)
-    let width = measure([#ancestor-number#"  "]).width
-    total-indent += width
+    total-indent += measure([#ancestor-number#"  "]).width
   }
   total-indent
 }
 
-/// Formats a numbered paragraph with proper indentation.
+/// Calculates fixed indentation for DAF paragraph levels.
 ///
-/// Generates a properly formatted paragraph with AFH 33-337 compliant numbering
-/// and indentation. Uses explicit level and counter values to avoid nested-context
-/// state propagation issues.
+/// First nested level starts at `nested-first-level-indent` (1in); deeper levels
+/// add `nested-step` (0.5in) per additional depth.
 ///
-/// - body (content): Paragraph content to format
 /// - level (int): Paragraph nesting level (0-based)
-/// - level-counts (dictionary): Current counter values per level
-/// -> content
-#let format-numbered-par(body, level, level-counts) = {
-  let current-value = level-counts.at(str(level), default: 1)
-  let format = get-paragraph-numbering-format(level)
-  let number-text = numbering(format, current-value)
-  let indent-width = calculate-indent-from-counts(level, level-counts)
-  [#h(indent-width)#number-text#"  "#body]
+/// -> length
+#let calculate-daf-indent(level) = {
+  if level <= 0 {
+    return 0pt
+  }
+  daf-paragraph.nested-first-level-indent + (level - 1) * daf-paragraph.nested-step
 }
 
-/// Formats a continuation paragraph within a multi-block list item.
+/// Resets counter entries from `start` upward to 1 in the level-counts dictionary.
+#let reset-levels-from(level-counts, start, max-levels) = {
+  for child in range(start, max-levels) {
+    level-counts.insert(str(child), 1)
+  }
+  level-counts
+}
+
+/// Formats a paragraph (or continuation) with a given indent strategy.
 ///
-/// Renders a paragraph that belongs to the same list item as the preceding
-/// numbered paragraph. The text is indented to align with the first character
-/// of the preceding numbered paragraph's text (past the number and spacing),
-/// but no new number is generated.
-///
-/// - body (content): Continuation paragraph content to format
-/// - level (int): Paragraph nesting level (0-based)
+/// - body (content): Paragraph content
+/// - level (int): Nesting level (0-based)
 /// - level-counts (dictionary): Current counter values per level
+/// - indent-fn (function): `(level, level-counts) -> length`
+/// - continuation (bool): If true, adds number-label width to alignment
 /// -> content
-#let format-continuation-par(body, level, level-counts) = {
-  let indent-width = calculate-indent-from-counts(level, level-counts)
-  // Add the width of the current level's number + spacing to align with text
-  let current-value = level-counts.at(str(level), default: 1)
-  let format = get-paragraph-numbering-format(level)
-  let number-text = numbering(format, current-value)
-  let number-width = measure([#number-text#"  "]).width
-  [#h(indent-width + number-width)#body]
+#let format-par(body, level, level-counts, indent-fn, continuation: false) = {
+  let indent-width = indent-fn(level, level-counts)
+  if continuation {
+    let current-value = level-counts.at(str(level), default: 1)
+    let number-text = numbering(get-paragraph-numbering-format(level), current-value)
+    [#h(indent-width + measure([#number-text#"  "]).width)#body]
+  } else {
+    let current-value = level-counts.at(str(level), default: 1)
+    let number-text = numbering(get-paragraph-numbering-format(level), current-value)
+    [#h(indent-width)#number-text#"  "#body]
+  }
 }
 
 // =============================================================================
@@ -103,7 +90,7 @@
 // - "A single paragraph is not numbered" (§2)
 // - First paragraph flush left, never indented
 // - Indent sub-paragraphs to align with first character of parent paragraph text
-#let render-body(content, auto-numbering: true) = {
+#let render-body(content, auto-numbering: true, memo-style: "usaf") = {
   let PAR_BUFFER = state("PAR_BUFFER")
   PAR_BUFFER.update(())
   let NEST_DOWN = counter("NEST_DOWN")
@@ -254,6 +241,11 @@
 
       // Format based on element kind
       let nest_level = item.nest_level
+      let indent-fn = if memo-style == "daf" {
+        (level, _counts) => calculate-daf-indent(level)
+      } else {
+        (level, counts) => calculate-indent-from-counts(level, counts)
+      }
       let final_par = {
         if kind == "table" {
           render-memo-table(item_content)
@@ -261,22 +253,37 @@
           // Continuation block within a multi-block list item:
           // indent to align with preceding numbered paragraph's text, no new number.
           // level-counts still holds the value of the preceding numbered paragraph.
-          if auto-numbering {
-            format-continuation-par(item_content, nest_level, level-counts)
+          if memo-style == "daf" {
+            if nest_level > 0 {
+              format-par(item_content, nest_level, level-counts, indent-fn, continuation: true)
+            } else {
+              item_content
+            }
+          } else if auto-numbering {
+            format-par(item_content, nest_level, level-counts, indent-fn, continuation: true)
           } else if nest_level > 0 {
-            format-continuation-par(item_content, nest_level - 1, level-counts)
+            format-par(item_content, nest_level - 1, level-counts, indent-fn, continuation: true)
           } else {
             item_content
+          }
+        } else if memo-style == "daf" {
+          if nest_level > 0 {
+            let par = format-par(item_content, nest_level, level-counts, indent-fn)
+            level-counts.insert(str(nest_level), level-counts.at(str(nest_level), default: 1) + 1)
+            level-counts = reset-levels-from(level-counts, nest_level + 1, max-levels)
+            par
+          } else {
+            // DAF top-level paragraphs are unnumbered and first-line indented.
+            // Reset nested counters so each new top-level paragraph restarts children.
+            level-counts = reset-levels-from(level-counts, 0, max-levels)
+            [#h(daf-paragraph.top-first-line-indent)#item_content]
           }
         } else if auto-numbering {
           if par_count > 1 {
             // Apply paragraph numbering per AFH 33-337 §2
-            let par = format-numbered-par(item_content, nest_level, level-counts)
-            // Advance counter for this level and reset child levels
+            let par = format-par(item_content, nest_level, level-counts, indent-fn)
             level-counts.insert(str(nest_level), level-counts.at(str(nest_level)) + 1)
-            for child in range(nest_level + 1, max-levels) {
-              level-counts.insert(str(child), 1)
-            }
+            level-counts = reset-levels-from(level-counts, nest_level + 1, max-levels)
             par
           } else {
             // AFH 33-337 §2: "A single paragraph is not numbered"
@@ -286,18 +293,14 @@
           // Unnumbered mode: only explicitly nested items (enum/list) get numbered
           if nest_level > 0 {
             let effective_level = nest_level - 1
-            let par = format-numbered-par(item_content, effective_level, level-counts)
+            let par = format-par(item_content, effective_level, level-counts, indent-fn)
             level-counts.insert(str(effective_level), level-counts.at(str(effective_level)) + 1)
-            for child in range(effective_level + 1, max-levels) {
-              level-counts.insert(str(child), 1)
-            }
+            level-counts = reset-levels-from(level-counts, effective_level + 1, max-levels)
             par
           } else {
-            // Base-level paragraphs are flush left with no numbering
-            // Reset all child level counters so subsequent list items restart at 1
-            for child in range(max-levels) {
-              level-counts.insert(str(child), 1)
-            }
+            // Base-level paragraphs are flush left with no numbering.
+            // Reset all child level counters so subsequent list items restart at 1.
+            level-counts = reset-levels-from(level-counts, 0, max-levels)
             item_content
           }
         }

--- a/src/config.typ
+++ b/src/config.typ
@@ -21,8 +21,8 @@
 // =============================================================================
 // AFH 33-337 §5: "Use 12 point Times New Roman font for text"
 
-#let DEFAULT_LETTERHEAD_FONTS = ("Copperplate CC",)
-#let DEFAULT_BODY_FONTS = ("times new roman", "NimbusRomNo9L")  // AFH 33-337 §5: Times New Roman required
+#let DEFAULT_LETTERHEAD_FONTS = ("NimbusRomNo9L", "times new roman")
+#let DEFAULT_BODY_FONTS = ("NimbusRomNo9L", "times new roman")  // AFH 33-337 §5: Times New Roman required
 #let LETTERHEAD_COLOR = rgb("#204093")  // Faded USAF blue for letterhead
 
 // =============================================================================
@@ -37,6 +37,14 @@
   // AFH 33-337 §2: Hierarchical paragraph numbering format
   // Level 0: 1., 2., 3. | Level 1: a., b., c. | Level 2: (1), (2), (3) | Level 3: (a), (b), (c)
   numbering-formats: ("1.", "a.", "(1)", "(a)", n => underline(str(n)), n => underline(str(n))),
+)
+
+// DAF (Headquarters) memo body: first-line indent for unnumbered paragraphs; nested
+// items start at 1in, then +0.5in per additional nesting depth.
+#let daf-paragraph = (
+  top-first-line-indent: 0.5in,
+  nested-first-level-indent: 1in,
+  nested-step: 0.5in,
 )
 
 // =============================================================================
@@ -58,7 +66,6 @@
 
 #let CLASSIFICATION_COLORS = (
   "UNCLASSIFIED": rgb(0, 122, 51), // Forest green (#007A33)
-  "CONFIDENTIAL": rgb(0, 51, 160), // Deep blue (#0033A0)
   "SECRET": rgb(200, 16, 46), // Crimson red (#C8102E)
   "TOP SECRET": rgb(255, 103, 31), // Burnt orange (#FF671F)
 )

--- a/src/frontmatter.typ
+++ b/src/frontmatter.typ
@@ -18,6 +18,7 @@
   letterhead_title: "DEPARTMENT OF THE AIR FORCE",
   letterhead_caption: "[YOUR SQUADRON/UNIT NAME]",
   letterhead_seal: none,
+  letterhead_seal_subtitle: none, // optional line under seal (9pt bold caps); ignored if no seal
   letterhead_font: DEFAULT_LETTERHEAD_FONTS,
   body_font: DEFAULT_BODY_FONTS,
   font_size: 12pt,
@@ -25,11 +26,16 @@
   classification_level: none,
   footer_tag_line: none,
   auto_numbering: true,
+  memo_style: "usaf",
   it,
 ) = {
   assert(subject != none, message: "subject is required")
   assert(memo_for != none, message: "memo_for is required")
   assert(memo_from != none, message: "memo_from is required")
+  assert(
+    memo_style in ("usaf", "daf"),
+    message: "memo_style must be \"usaf\" or \"daf\"",
+  )
 
   let actual_date = if date == none { datetime.today() } else { date }
   let classification_color = get-classification-level-color(classification_level)
@@ -89,13 +95,19 @@
     },
   )
 
-  render-letterhead(letterhead_title, letterhead_caption, letterhead_seal, letterhead_font)
+  render-letterhead(
+    letterhead_title,
+    letterhead_caption,
+    letterhead_font,
+    letterhead-seal: letterhead_seal,
+    letterhead-seal-subtitle: letterhead_seal_subtitle,
+  )
 
   // AFH 33-337 "Date": "Place the date 1 inch from the right edge, 1.75 inches from the top"
   // Since we have a 1-inch top margin, we need (1.75in - margin) vertical space
   v(1.75in - spacing.margin)
 
-  render-date-section(actual_date)
+  render-date-section(actual_date, memo-style: memo_style)
   render-for-section(memo_for, memo_for_cols)
   render-from-section(memo_from)
   render-subject-section(subject)
@@ -108,6 +120,7 @@
     body_font: body_font,
     font_size: font_size,
     auto_numbering: auto_numbering,
+    memo_style: memo_style,
   ))
 
   it

--- a/src/indorsement.typ
+++ b/src/indorsement.typ
@@ -51,6 +51,7 @@
 
     context {
       let config = query(metadata).last().value
+      let memo-style = config.at("memo_style", default: "usaf")
       let original_subject = config.subject
       let original_date = config.original_date
       let original_from = config.original_from
@@ -61,12 +62,12 @@
 
       if format == "separate_page" {
         pagebreak()
-        [#indorsement_label to #original_from, #display-date(original_date), #original_subject]
+        [#indorsement_label to #original_from, #display-date(original_date, memo-style: memo-style), #original_subject]
 
         blank-line()
         grid(
           columns: (auto, 1fr),
-          ind_from, align(right)[#display-date(actual_date)],
+          ind_from, align(right)[#display-date(actual_date, memo-style: memo-style)],
         )
 
         blank-line()
@@ -78,7 +79,7 @@
         blank-line()
         grid(
           columns: (auto, 1fr),
-          [#indorsement_label, #ind_from], align(right)[#display-date(actual_date)],
+          [#indorsement_label, #ind_from], align(right)[#display-date(actual_date, memo-style: memo-style)],
         )
 
         blank-line()
@@ -96,23 +97,15 @@
     render-action-line(action)
   }
 
-  render-body(content)
+  context {
+    let memo-style = {
+      let items = query(metadata)
+      if items.len() > 0 { items.last().value.at("memo_style", default: "usaf") } else { "usaf" }
+    }
+    render-body(content, memo-style: memo-style)
+  }
 
   render-signature-block(signature_block, signature-blank-lines: signature_blank_lines)
 
-  if not falsey(attachments) {
-    calculate-backmatter-spacing(true)
-    let attachment-count = attachments.len()
-    let section-label = if attachment-count == 1 { "Attachment:" } else { str(attachment-count) + " Attachments:" }
-    let continuation-label = (
-      (if attachment-count == 1 { "Attachment" } else { str(attachment-count) + " Attachments" })
-        + " (listed on next page):"
-    )
-    render-backmatter-section(attachments, section-label, numbering-style: "1.", continuation-label: continuation-label)
-  }
-
-  if not falsey(cc) {
-    calculate-backmatter-spacing(falsey(attachments))
-    render-backmatter-section(cc, "cc:")
-  }
+  render-backmatter-sections(attachments: attachments, cc: cc)
 }

--- a/src/lib.typ
+++ b/src/lib.typ
@@ -22,18 +22,20 @@
 //
 // Basic usage:
 //
-// #import "@preview/tonguetoquill-usaf-memo:2.0.0": frontmatter, mainmatter, backmatter, indorsement
+// #import "@preview/tonguetoquill-usaf-memo:3.0.0": frontmatter, mainmatter, backmatter, indorsement
 //
 // #show: frontmatter.with(
 //   subject: "Your Subject Here",
 //   memo_for: ("OFFICE/SYMBOL",),
 //   memo_from: ("YOUR/SYMBOL",),
+//   memo_style: "usaf", // "usaf" (default) or "daf"
 // )
 //
 // #show: mainmatter
 //
 // Your memo body content here.
-// (Paragraphs are automatically numbered per AFH 33-337)
+// (USAF style auto-numbers per AFH 33-337; DAF style uses unnumbered
+// top-level paragraphs with fixed 0.5in first-line indentation)
 //
 // #backmatter(
 //   signature_block: ("NAME, Rank, USAF", "Title"),

--- a/src/mainmatter.typ
+++ b/src/mainmatter.typ
@@ -3,7 +3,6 @@
 // This module implements the mainmatter (body text) of a USAF memorandum per
 // AFH 33-337 Chapter 14 "The Text of the Official Memorandum" (§1-12).
 
-#import "primitives.typ": *
 #import "body.typ": *
 
 /// Mainmatter show rule for USAF memorandum body content.
@@ -19,7 +18,7 @@
 /// of the memorandum. Automatically detects single vs. multiple paragraphs
 /// to comply with AFH 33-337 numbering requirements.
 ///
-/// When auto_numbering is false (set in frontmatter), base-level paragraphs
+/// When `auto_numbering` is false (set in frontmatter), base-level paragraphs
 /// render flush left without numbering. Only explicitly numbered or bulleted
 /// items enter the numbering hierarchy.
 ///
@@ -28,5 +27,6 @@
 #let mainmatter(it) = context {
   let config = query(metadata).last().value
   let auto-numbering = config.at("auto_numbering", default: true)
-  render-body(it, auto-numbering: auto-numbering)
+  let memo-style = config.at("memo_style", default: "usaf")
+  render-body(it, auto-numbering: auto-numbering, memo-style: memo-style)
 }

--- a/src/primitives.typ
+++ b/src/primitives.typ
@@ -14,9 +14,18 @@
 // Letterhead placement is not explicitly specified in AFH 33-337, but follows
 // standard USAF memo formatting conventions
 
-#let render-letterhead(title, caption, letterhead-seal, font) = {
+#let render-letterhead(
+  title,
+  caption,
+  font,
+  letterhead-seal: none,
+  letterhead-seal-subtitle: none,
+) = {
   font = ensure-array(font)
+  title = ensure-string(title)
   caption = ensure-string(caption)
+  title = upper(title)
+  caption = upper(caption)
 
   place(
     dy: 0.625in - spacing.margin,
@@ -28,7 +37,7 @@
         #place(
           center + top,
           align(center)[
-            #set text(12pt, font: font, fill: LETTERHEAD_COLOR)
+            #set text(12pt, font: font, fill: LETTERHEAD_COLOR, weight: "bold")
             #title\
             #text(10.5pt)[#caption]
           ],
@@ -38,13 +47,27 @@
   )
 
   if letterhead-seal != none {
+    let seal-body = if falsey(letterhead-seal-subtitle) {
+      block[
+        #fit-box(width: 2in, height: 1in)[#letterhead-seal]
+      ]
+    } else {
+      block(width: 2in)[
+        #align(left)[
+          #stack(spacing: 0.15em)[
+            #fit-box(width: 2in, height: 1in)[#letterhead-seal]
+            #text(9pt, font: font, fill: LETTERHEAD_COLOR, weight: "bold")[
+              #upper(ensure-string(letterhead-seal-subtitle))
+            ]
+          ]
+        ]
+      ]
+    }
     place(
       left + top,
       dx: -0.5in,
       dy: -.5in,
-      block[
-        #fit-box(width: 2in, height: 1in)[#letterhead-seal]
-      ],
+      seal-body,
     )
   }
 }
@@ -59,8 +82,8 @@
 // - SUBJECT: Second line below FROM
 
 // AFH 33-337 "Date": "Place the date 1 inch from the right edge, 1.75 inches from the top"
-#let render-date-section(date) = {
-  align(right)[#display-date(date)]
+#let render-date-section(date, memo-style: "usaf") = {
+  align(right)[#display-date(date, memo-style: memo-style)]
 }
 
 // AFH 33-337 "MEMORANDUM FOR": "Place 'MEMORANDUM FOR' on the second line below the date"
@@ -107,7 +130,7 @@
     blank-line()
     grid(
       columns: (auto, auto, 1fr),
-      "References:", "  ", enum(..references, numbering: "(a)"),
+      "References:", "  ", enum(..references, numbering: "(a) ", body-indent: 0pt),
     )
   }
 }
@@ -234,10 +257,12 @@
   context {
     let available-space = page.height - here().position().y - 1in
     if measure(formatted-content).height > available-space {
+      // Attachments pass continuation-label ("… (listed on next page):" per AFH 33-337).
+      // cc: and DISTRIBUTION: use a neutral default — "listed" applies to attachment lists only.
       let continuation-text = if continuation-label != none {
         text()[#continuation-label]
       } else {
-        text()[#section-label + " (listed on next page):"]
+        text()[#(section-label + " (continued on next page)")]
       }
       continuation-text
       pagebreak()

--- a/src/utils.typ
+++ b/src/utils.typ
@@ -79,86 +79,51 @@
   ]
 }
 
-/// Checks if a string is in ISO date format (YYYY-MM-DD or YYYY-MM-DDTHH:MM:SS).
+/// Formats a date for the memo heading.
 ///
-/// Performs a simple pattern check for ISO 8601 date strings by verifying:
-/// - String is at least 10 characters long
-/// - Characters at positions 4 and 7 are dashes
-///
-/// - date-str (str): String to check for ISO date pattern
-/// -> bool
-#let is-iso-date-string(date-str) = {
-  if date-str.len() == 10 {
-    let char4 = date-str.at(4)
-    let char7 = date-str.at(7)
-    return char4 == "-" and char7 == "-"
-  } else if date-str.len() > 10 {
-    let char4 = date-str.at(4)
-    let char7 = date-str.at(7)
-    let char10 = date-str.at(10)
-    return char4 == "-" and char7 == "-" and char10 == "T"
-  }
-  return false
-}
-
-/// Extracts the date portion (YYYY-MM-DD) from an ISO date string.
-///
-/// Returns the first 10 characters which contain the date portion of an
-/// ISO 8601 date string, removing any time component if present.
-///
-/// - date-str (str): ISO date string to extract from
-/// -> str
-#let extract-iso-date(date-str) = {
-  date-str.slice(0, 10)
-}
-
-/// Formats a date in standard military format or ISO format depending on input type.
-///
-/// AFH 33-337 "Date": "Use the 'Day Month Year' or 'DD Mmm YY' format for documents
-/// addressed to a military organization. For civilian addressees, use the 'Month Day, Year' format."
-/// Examples: "15 October 2014" or "15 Oct 14" for military, "October 15, 2014" for civilian
-///
-/// Intelligently handles different date input formats:
-/// - ISO string (YYYY-MM-DD or YYYY-MM-DDTHH:MM:SS): Parsed via TOML and displayed in military format
-/// - Non-ISO string: Displayed as-is
-/// - datetime object: Displayed in military format ("1 January 2024")
+/// - String: shown as-is (use for fixed text like placeholders).
+/// - datetime: USAF style `DD Month YYYY`; DAF style `Month DD, YYYY`.
 ///
 /// - date (str|datetime): Date to format for display
-/// -> str
-#let display-date(date) = {
+/// - memo-style (str): `"usaf"` or `"daf"`
+/// -> content
+#let display-date(date, memo-style: "usaf") = {
+  assert(
+    memo-style in ("usaf", "daf"),
+    message: "memo-style for display-date must be \"usaf\" or \"daf\"",
+  )
   if type(date) == str {
-    if is-iso-date-string(date) {
-      // Parse ISO date string using TOML to get datetime object
-      let iso-date = extract-iso-date(date)
-      let toml-str = "date = " + iso-date
-      let parsed = toml(bytes(toml-str))
-      parsed.date.display("[day padding:none] [month repr:long] [year]")
-    } else {
-      date
-    }
+    date
   } else {
-    date.display("[day padding:none] [month repr:long] [year]")
+    let pattern = if memo-style == "daf" {
+      "[month repr:long] [day padding:none], [year]"
+    } else {
+      "[day padding:none] [month repr:long] [year]"
+    }
+    date.display(pattern)
   }
 }
 
-/// Gets the color associated with a classification level.
+/// Gets the banner color for a classification marking.
 ///
-/// - level (str): Classification level string
+/// Matches when `level` (trimmed) starts with a known prefix: TOP SECRET, SECRET, or UNCLASSIFIED.
+/// Otherwise returns black.
+///
+/// - level (str): Marking string shown in header/footer
 /// -> color
 #let get-classification-level-color(level) = {
-  if level == none {
-    return rgb(0, 0, 0) // Default to black if no classification
+  if level == none or type(level) != str {
+    return rgb(0, 0, 0)
   }
-  // Order matters - check most specific first
-  let level-order = ("TOP SECRET", "SECRET", "CONFIDENTIAL", "UNCLASSIFIED")
-
+  let s = level.trim()
+  // "TOP SECRET" before "SECRET" so the full phrase matches first.
+  let level-order = ("TOP SECRET", "SECRET", "UNCLASSIFIED")
   for base-level in level-order {
-    if base-level in level {
+    if s.starts-with(base-level) {
       return CLASSIFICATION_COLORS.at(base-level)
     }
   }
-
-  rgb(0, 0, 0) // Default
+  rgb(0, 0, 0)
 }
 
 // =============================================================================

--- a/templates/loc.md
+++ b/templates/loc.md
@@ -48,7 +48,6 @@ CARD: indorsement
 from: SUBJECT RANK FIRST M. LAST
 for: ISSUER ORG/SYMBOL
 signature_block: SUBJECT FIRST M. LAST, RANK, USAF
-date: "Date: _____________"
 ---
 
 <!-- EDIT: Second Indorsement: Subject's response - choose one option -->
@@ -59,7 +58,6 @@ CARD: indorsement
 from: ISSUER RANK FIRST M. LAST
 for: SUBJECT RANK FIRST M. LAST
 signature_block: ISSUER FIRST M. LAST, RANK, USAF
-date: "Date: _____________"
 ---
 
 <!-- EDIT: Third Indorsement: Issuer's final decision - choose appropriate options -->
@@ -70,7 +68,6 @@ CARD: indorsement
 from: SUBJECT RANK FIRST M. LAST
 for: ISSUER ORG/SYMBOL
 signature_block: SUBJECT FIRST M. LAST, RANK, USAF
-date: "Date: _____________"
 ---
 
 <!-- EDIT: Fourth Indorsement: Subject acknowledges final decision -->

--- a/typst.toml
+++ b/typst.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tonguetoquill-usaf-memo"
-version = "2.0.0"
+version = "3.0.0"
 compiler = "0.14.0"
 entrypoint = "src/lib.typ"
 repository = "https://github.com/nibsbin/tonguetoquill-usaf-memo"


### PR DESCRIPTION
## Summary

This PR updates the USAF memo quill (0.2.0) Typst package and authoring surface:

- **Memo formats**: Add `memo_style` for USAF vs DAF layouts in `plate.typ` and `Quill.yaml`.
- **Letterhead**: Add `letterhead_seal_subtitle` for optional seal subtitle text.
- **Schema**: Refine `memo_style` and reintroduce classification level fields for clearer structure.
- **Tooling**: Dependency updates and improved error handling in the validation script; subtree update script hardening and upstream package sync.

## Testing

- [ ] `quill validate` / project validation as applicable
- [ ] Compile sample memo if you maintain one in CI or locally
